### PR TITLE
✨ feat(client): add GameResult Modal ("feat #78")

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -4,8 +4,9 @@ import LandingPage from './pages/LandingPage';
 import ProfilePage from './pages/ProfilePage';
 import ChatroomPage from './pages/ChatChannelPage';
 import NicknamePage from './pages/NicknamePage';
-import GamePage from './pages/GamePage';
+import GameCreatePage from './pages/GameCreatePage';
 import GameLodingPage from './pages/GameLodingPage';
+import GamePlayPage from './pages/GamePlayPage';
 
 function App() {
   return (
@@ -14,8 +15,10 @@ function App() {
       <Route path="/nickname" element={<NicknamePage />} />
       <Route path="/profile" element={<ProfilePage />} />
       <Route path="/chatRoom" element={<ChatroomPage />} />
-      <Route path="/game" element={<GamePage />} />
-      <Route path="/gameLoding" element={<GameLodingPage />} />  {/* 추후에 url을 통해 직접들어가지 못하고 game 버튼을 통해서만 접근 가능하도록 수정 */}
+      <Route path="/gameCreate" element={<GameCreatePage />} />
+      <Route path="/gamePlay" element={<GamePlayPage />} />
+      <Route path="/gameLoding" element={<GameLodingPage />} />
+      {/* 추후에 url을 통해 직접들어가지 못하고 game 버튼을 통해서만 접근 가능하도록 수정 */}
     </Routes>
   );
 }

--- a/packages/client/src/atoms/ProfileAvatar.tsx
+++ b/packages/client/src/atoms/ProfileAvatar.tsx
@@ -40,14 +40,14 @@ const StyledBadge = styled(Badge)(({ theme }) => ({
   },
 }));
 
-function ProfileAvatar(avaterType: String) {
-  if (avaterType === 'default') {
+function ProfileAvatar(avatarType: String | undefined) {
+  if (avatarType === 'default') {
     return (
       <ProfileAvatarLayout>
         <Avatar alt="Remy Sharp" src="/static/images/avatar/1.jpg" />
       </ProfileAvatarLayout>
     );
-  } else if (avaterType === 'circle') {
+  } else if (avatarType === 'circle') {
     return (
       <ProfileAvatarLayout>
         <StyledBadge

--- a/packages/client/src/atoms/TextBox.tsx
+++ b/packages/client/src/atoms/TextBox.tsx
@@ -2,12 +2,26 @@ import { styled } from '@mui/material/styles';
 
 const UserProfileBoxNicknameLayout = styled('text')(({ theme }) => ({
   margin: '1rem',
+  flexWrap: 'wrap',
 }));
 
-function TextBox(props: { value: string | undefined, size: string | undefined, fontColor: string | undefined }) {
+function TextBox(props: {
+  value: string | undefined;
+  size: string | undefined;
+  fontColor: string | undefined;
+}) {
   const { value, size, fontColor } = props;
 
-  return <UserProfileBoxNicknameLayout style={{ fontSize: size ? size : '5rem', color: fontColor ? fontColor : 'black' }}>{value}</UserProfileBoxNicknameLayout>;
+  return (
+    <UserProfileBoxNicknameLayout
+      style={{
+        fontSize: size ? size : '5rem',
+        color: fontColor ? fontColor : 'black',
+      }}
+    >
+      {value}
+    </UserProfileBoxNicknameLayout>
+  );
 }
 
 export default TextBox;

--- a/packages/client/src/modules/GameSecton/GameResultMadal.tsx
+++ b/packages/client/src/modules/GameSecton/GameResultMadal.tsx
@@ -1,0 +1,105 @@
+import * as React from 'react';
+import Box from '@mui/material/Box';
+import Modal from '@mui/material/Modal';
+import Button from '@mui/material/Button';
+import { styled } from '@mui/material';
+import UserProfileBox from '../ProfileSection/UserProfileBox';
+import { color } from '@mui/system';
+import GameScore from './GameScore';
+
+const style = {
+  position: 'absolute' as 'absolute',
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
+  width: 400,
+  bgcolor: '#6D52F6',
+  border: '2px solid #6002F6',
+  boxShadow: 24,
+  pt: 2,
+  px: 4,
+  pb: 3,
+};
+
+const UserProfileBoxLayout = styled('div')(({ theme }) => ({
+  gridArea: 'UserProfileBoxLayout',
+}));
+
+const OtherProfileBoxLayout = styled('div')(({ theme }) => ({
+  gridArea: 'OtherProfileBoxLayout',
+}));
+
+const GameScoreLayout = styled('div')(({ theme }) => ({
+  gridArea: 'GameScoreLayout',
+}));
+
+const ExitButtonLayout = styled('div')(({ theme }) => ({
+  gridArea: 'ExitButtonLayout',
+  backgroundColor: '#6002F6',
+}));
+
+const GameResultLayout = styled('div')(({ theme }) => ({
+  display: 'grid',
+  gridTemplateColumns: '1fr 1fr',
+  gridAutoRows: '10%', //gap의 값(5 * 3%)을 생각하여 계산해야됨
+  gridTemplateAreas: `'UserProfileBoxLayout OtherProfileBoxLayout' 
+                      'UserProfileBoxLayout OtherProfileBoxLayout' 
+                      'GameScoreLayout GameScoreLayout' 
+                      'GameScoreLayout GameScoreLayout' 
+                      'GameScoreLayout GameScoreLayout' 
+                      'GameScoreLayout GameScoreLayout' 
+                      'GameScoreLayout GameScoreLayout' 
+                      'GameScoreLayout GameScoreLayout' 
+                      'GameScoreLayout GameScoreLayout' 
+                      'ExitButtonLayout ExitButtonLayout'`,
+  alignItems: 'center',
+  justifyItems: 'center',
+  alignContents: 'center',
+  justifyContents: 'center',
+}));
+
+function GameResultModal() {
+  const [open, setOpen] = React.useState(false);
+  const handleOpen = () => {
+    setOpen(true);
+  };
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  return (
+    <div>
+      <Button onClick={handleOpen}>
+        Open Duis mollis, est non commodo luctus, nisi erat porttitor ligula.
+        modal
+      </Button>
+      <Modal
+        open={open}
+        onClose={handleClose}
+        aria-labelledby="parent-modal-title"
+        aria-describedby="parent-modal-description"
+      >
+        <Box sx={{ ...style, width: 400 }}>
+          <GameResultLayout>
+            <UserProfileBoxLayout>
+              {UserProfileBox(false, 'default')}
+            </UserProfileBoxLayout>
+            <OtherProfileBoxLayout>
+              {UserProfileBox(false, 'circle')}
+            </OtherProfileBoxLayout>
+            <GameScoreLayout>
+              <GameScore player1Score={'10'} player2Score={'9'} />
+              {/* {GameScore({ player1Score: '10', player2Score: '9' })} */}
+            </GameScoreLayout>
+            <ExitButtonLayout>
+              <Button onClick={handleClose} style={{ color: 'white' }}>
+                나가기
+              </Button>
+            </ExitButtonLayout>
+          </GameResultLayout>
+        </Box>
+      </Modal>
+    </div>
+  );
+}
+export default GameResultModal;

--- a/packages/client/src/modules/GameSecton/GameScore.tsx
+++ b/packages/client/src/modules/GameSecton/GameScore.tsx
@@ -1,0 +1,14 @@
+import Box from '@mui/material/Box';
+import TextBox from '../../atoms/TextBox';
+
+function GameScore(props: { player1Score: string; player2Score: string }) {
+  const { player1Score, player2Score } = props;
+  return (
+    <Box sx={{ display: 'flex' }}>
+      <TextBox value={player1Score} size={'5rem'} fontColor={'black'} />
+      <TextBox value={':'} size={'5rem'} fontColor={'black'} />
+      <TextBox value={player2Score} size={'5rem'} fontColor={'black'} />
+    </Box>
+  );
+}
+export default GameScore;

--- a/packages/client/src/organisms/GamePlaySection/GamePlayWindow.tsx
+++ b/packages/client/src/organisms/GamePlaySection/GamePlayWindow.tsx
@@ -1,0 +1,18 @@
+import styled from '@emotion/styled';
+import GameResultModal from '../../modules/GameSecton/GameResultMadal';
+
+const GameWindowLayout = styled('div')(({ theme }) => ({
+  backgroundColor: 'black',
+  width: '100%',
+  height: '90%',
+}));
+
+function GamePlayWindowOrganism() {
+  return (
+    <GameWindowLayout>
+      <GameResultModal />
+    </GameWindowLayout>
+  );
+}
+
+export default GamePlayWindowOrganism;

--- a/packages/client/src/pages/GameCreatePage.tsx
+++ b/packages/client/src/pages/GameCreatePage.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import NavigationBar from '../components/bar/NavigationBar';
 import GameCreateTemplate from '../template/GameCreateSection/GameCreateTemplate';
 
-const GameLayout = styled('section')(({ theme }) => ({
+const GameCreateLayout = styled('section')(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
   backgroundColor: '#6BADE2',
@@ -15,25 +15,25 @@ const NavGridLayout = styled('section')(({ theme }) => ({
   height: '10%',
 }));
 
-const GameTemplateLayout = styled('section')(({ theme }) => ({
+const GameCreateTemplateLayout = styled('section')(({ theme }) => ({
   display: 'flex',
   width: '100%',
   height: '90%',
   alignItems: 'center',
   justifyContent: 'center', //justifySelf: 'center'는 왜 안될까..
-}))
+}));
 
-function GamePage() {
+function GameCreatePage() {
   return (
-    <GameLayout>
+    <GameCreateLayout>
       <NavGridLayout>
         <NavigationBar></NavigationBar>
       </NavGridLayout>
-      <GameTemplateLayout>
+      <GameCreateTemplateLayout>
         <GameCreateTemplate buttonType={'invite'} />
-      </GameTemplateLayout>
-    </GameLayout>
+      </GameCreateTemplateLayout>
+    </GameCreateLayout>
   );
 }
 
-export default GamePage;
+export default GameCreatePage;

--- a/packages/client/src/pages/GamePlayPage.tsx
+++ b/packages/client/src/pages/GamePlayPage.tsx
@@ -1,0 +1,40 @@
+import styled from '@emotion/styled';
+import NavigationBar from '../components/bar/NavigationBar';
+import GameCreateTemplate from '../template/GameCreateSection/GameCreateTemplate';
+import GamePlayTemplate from '../template/GameCreateSection/GamePlayTemplate';
+
+const GamePlayLayout = styled('section')(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  backgroundColor: '#6BADE2',
+  height: '100%',
+  width: '100%',
+}));
+
+const NavGridLayout = styled('section')(({ theme }) => ({
+  width: '100%',
+  height: '10%',
+}));
+
+const GamePlayTemplateLayout = styled('section')(({ theme }) => ({
+  display: 'flex',
+  width: '100%',
+  height: '90%',
+  alignItems: 'center',
+  justifyContent: 'center', //justifySelf: 'center'는 왜 안될까..
+}));
+
+function GamePlayPage() {
+  return (
+    <GamePlayLayout>
+      <NavGridLayout>
+        <NavigationBar></NavigationBar>
+      </NavGridLayout>
+      <GamePlayTemplateLayout>
+        <GamePlayTemplate />
+      </GamePlayTemplateLayout>
+    </GamePlayLayout>
+  );
+}
+
+export default GamePlayPage;

--- a/packages/client/src/template/GameCreateSection/GamePlayTemplate.tsx
+++ b/packages/client/src/template/GameCreateSection/GamePlayTemplate.tsx
@@ -1,0 +1,41 @@
+import styled from '@emotion/styled';
+import TextBox from '../../atoms/TextBox';
+import GameCreateMainOrganism from '../../organisms/GameCreateSection/GameCreateMainSection';
+import GamePlayWindowOrganism from '../../organisms/GamePlaySection/GamePlayWindow';
+
+const GameTemplateLayout = styled('section')(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  alignContent: 'center',
+  backgroundColor: '#194DD2',
+  width: '80%',
+  height: '85%',
+}));
+
+const GameHeaderLayout = styled('div')(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: '100%',
+  height: '10%',
+}));
+
+const GameSectionLayout = styled('div')(({ theme }) => ({
+  width: '100%',
+  height: '90%',
+}));
+
+function GamePlayTemplate() {
+  return (
+    <GameTemplateLayout>
+      <GameHeaderLayout>
+        <TextBox value={'Ladder'} size={'2rem'} fontColor={'black'} />
+      </GameHeaderLayout>
+      <GameSectionLayout>
+        <GamePlayWindowOrganism />
+      </GameSectionLayout>
+    </GameTemplateLayout>
+  );
+}
+
+export default GamePlayTemplate;


### PR DESCRIPTION
게임을 플레이할 수 있는 기본 창을 만들었고, 게임 결과를 보여주며 게임 창을 나가는 modal의 디자인 밎 레이아웃을 구현하였습니다.

"feat #78"

### 💡 작업 동기 (Motivation)
게임상황을 보여줄 수 있는 화면이 필요하였고,
게임 결과에 대한 정보를 보여주며 게임을 나갈 수 있는 모달 창이 필요하여 구현하였습니다.

### 💬 변경 사항 요약 (Key changes) 
- 게임 진행 화면을 만들기 위해 gamePlay라는 페이지를 만들었습니다.
- 게임 모달을 만들었습니다.

### ✅  체크리스트
- [x] 각 기능에 대한 단위 테스트 및 통합 테스트를 수정|업데이트|추가했습니다(해당되는 경우).
- [x] 콘솔에 오류나 경고가 없습니다.
- [x] 개발된 기능의 스크린샷에 참여했습니다(해당되는 경우).

### 📸 스크린샷 첨부
![스크린샷 2022-09-20 오후 7 43 32](https://user-images.githubusercontent.com/50915710/191237831-5c74237a-9ca5-46a9-aeea-38264d348b17.png)

### 📣 리뷰어들에게 요청사항
모달의 구조 자체는 mui에서 받아와서 수정이 잘 안되어 아래의 스크린샷처럼 크기는 고정입니다..
유저의 닉네임이 길다면 보여주는 방식에 문제가 생길 수 있을 것 같아 닉네임 길이에 제한을 두는것도 고려해 보면 좋을 것 같습니다.
![스크린샷 2022-09-20 오후 7 44 34](https://user-images.githubusercontent.com/50915710/191238040-4ec86af2-c5a0-4207-92b1-8d566bed4df5.png)
