### PR TITLE
♻️ refactor(client): navbar is changed to sub route ("close #96")

### DIFF
--- a/node_modules/.yarn-integrity
+++ b/node_modules/.yarn-integrity
@@ -1,5 +1,9 @@
 {
+<<<<<<< Updated upstream
   "systemParams": "darwin-arm64-108",
+=======
+  "systemParams": "darwin-x64-108",
+>>>>>>> Stashed changes
   "modulesFolders": [
     "node_modules",
     "node_modules",
@@ -59,6 +63,7 @@
     "eslint-plugin-prettier@^4.2.1",
     "eslint-plugin-prettier@^4.2.1",
     "eslint-plugin-react-hooks@^4.6.0",
+    "eslint-plugin-react-hooks@^4.6.0",
     "eslint-plugin-react@^7.31.5",
     "eslint-plugin-react@^7.31.5",
     "eslint@^8.0.1",
@@ -78,11 +83,18 @@
     "react-router-dom@^6.3.0",
     "react-scripts@5.0.1",
     "react@^18.2.0",
+<<<<<<< Updated upstream
     "reflect-metadata@^0.1.13",
     "rimraf@^3.0.2",
     "rxjs@^7.2.0",
     "server@0.0.1",
     "source-map-support@^0.5.20",
+=======
+    "recoil@^0.7.5",
+    "recoil@^0.7.5",
+    "recoil@^0.7.5",
+    "server@1.0.0",
+>>>>>>> Stashed changes
     "styled-components@^5.3.5",
     "supertest@^6.1.3",
     "swagger-ui-express@^4.5.0",
@@ -1056,7 +1068,7 @@
     "eslint-plugin-jest@^25.3.0": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-25.7.0.tgz",
     "eslint-plugin-jsx-a11y@^6.5.1": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.6.1.tgz",
     "eslint-plugin-prettier@^4.2.1": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz",
-    "eslint-plugin-react-hooks@^4.3.0": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
+    "eslint-plugin-react-hooks@^4.3.0": "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz#4c3e697ad95b77e93f8646aaa1630c1ba607edd3",
     "eslint-plugin-react-hooks@^4.6.0": "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz#4c3e697ad95b77e93f8646aaa1630c1ba607edd3",
     "eslint-plugin-react@^7.27.1": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.31.7.tgz",
     "eslint-plugin-react@^7.31.5": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.31.7.tgz",
@@ -1202,6 +1214,7 @@
     "graceful-fs@^4.2.9": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
     "grapheme-splitter@^1.0.4": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
     "gzip-size@^6.0.0": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
+    "hamt_plus@1.0.2": "https://registry.yarnpkg.com/hamt_plus/-/hamt_plus-1.0.2.tgz#e21c252968c7e33b20f6a1b094cd85787a265601",
     "handle-thing@^2.0.0": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
     "harmony-reflect@^1.4.6": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.2.tgz",
     "has-bigints@^1.0.1": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
@@ -1794,7 +1807,11 @@
     "readable-stream@^3.4.0": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
     "readable-stream@^3.6.0": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
     "readdirp@~3.6.0": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+<<<<<<< Updated upstream
     "rechoir@^0.6.2": "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384",
+=======
+    "recoil@^0.7.5": "https://registry.yarnpkg.com/recoil/-/recoil-0.7.5.tgz#9a33a03350cfd99e08bdd5b73bfc8b8b9ee751b9",
+>>>>>>> Stashed changes
     "recursive-readdir@^2.2.2": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.2.tgz",
     "redent@^3.0.0": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
     "reflect-metadata@^0.1.13": "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.13.tgz#67ae3ca57c972a2aa1642b10fe363fe32d49dc08",

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -8,6 +8,7 @@ import GameCreatePage from './pages/GameCreatePage';
 import GameLodingPage from './pages/GameLodingPage';
 import GamePlayPage from './pages/GamePlayPage';
 import { RecoilRoot } from 'recoil';
+import PingpongLayout from './pages/PingpongLayout';
 
 function App() {
   return (
@@ -15,11 +16,7 @@ function App() {
       <Routes>
         <Route path="/" element={<LandingPage />} />
         <Route path="/nickname" element={<NicknamePage />} />
-        <Route path="/profile" element={<ProfilePage />} />
-        <Route path="/chatRoom" element={<ChatroomPage />} />
-        <Route path="/gameCreate" element={<GameCreatePage />} />
-        <Route path="/gamePlay" element={<GamePlayPage />} />
-        <Route path="/gameLoding" element={<GameLodingPage />} />
+        <Route path="/pingpong/*" element={<PingpongLayout />} />
         {/* 추후에 url을 통해 직접들어가지 못하고 game 버튼을 통해서만 접근 가능하도록 수정 */}
       </Routes>
     </RecoilRoot>

--- a/packages/client/src/pages/ChatChannelPage.tsx
+++ b/packages/client/src/pages/ChatChannelPage.tsx
@@ -7,7 +7,7 @@ import ChatRoomListTemplate from '../template/ChatMainSection/ChatRoomListTempla
 
 const ChatChannel = styled('section')(({ theme }) => ({
   width: '100%',
-  height: '100%',
+  height: '95.7%',
   display: 'flex',
   flexDirection: 'column',
 }));
@@ -38,18 +38,13 @@ const Aside = styled('aside')(({ theme }) => ({
 function ChatroomPage() {
   return (
     <ChatChannel>
-      <header>
-        <nav>
-          <NavigationBar></NavigationBar>
-        </nav>
-      </header>
       <MainSection>
         <Aside>
           <ChatSidebarTemplate />
         </Aside>
         <Section>
-          {/* <ChatRoomListTemplate /> */}
-          <EnteredChatRoomTemplate />
+          <ChatRoomListTemplate />
+          {/* <EnteredChatRoomTemplate /> */}
           {/* <ChatRoomDefaultTemplate /> */}
         </Section>
       </MainSection>

--- a/packages/client/src/pages/GameCreatePage.tsx
+++ b/packages/client/src/pages/GameCreatePage.tsx
@@ -26,9 +26,6 @@ const GameCreateTemplateLayout = styled('section')(({ theme }) => ({
 function GameCreatePage() {
   return (
     <GameCreateLayout>
-      <NavGridLayout>
-        <NavigationBar></NavigationBar>
-      </NavGridLayout>
       <GameCreateTemplateLayout>
         <GameCreateTemplate buttonType={'invite'} />
       </GameCreateTemplateLayout>

--- a/packages/client/src/pages/GamePlayPage.tsx
+++ b/packages/client/src/pages/GamePlayPage.tsx
@@ -11,11 +11,6 @@ const GamePlayLayout = styled('section')(({ theme }) => ({
   width: '100%',
 }));
 
-const NavGridLayout = styled('section')(({ theme }) => ({
-  width: '100%',
-  height: '10%',
-}));
-
 const GamePlayTemplateLayout = styled('section')(({ theme }) => ({
   display: 'flex',
   width: '100%',
@@ -27,9 +22,6 @@ const GamePlayTemplateLayout = styled('section')(({ theme }) => ({
 function GamePlayPage() {
   return (
     <GamePlayLayout>
-      <NavGridLayout>
-        <NavigationBar></NavigationBar>
-      </NavGridLayout>
       <GamePlayTemplateLayout>
         <GamePlayTemplate />
       </GamePlayTemplateLayout>

--- a/packages/client/src/pages/PingpongLayout.tsx
+++ b/packages/client/src/pages/PingpongLayout.tsx
@@ -1,0 +1,37 @@
+import styled from '@emotion/styled';
+import { Route, Routes } from 'react-router-dom';
+import NavigationBar from '../atoms/bar/NavigationBar';
+import ChatroomPage from './ChatChannelPage';
+import GameCreatePage from './GameCreatePage';
+import GameLodingPage from './GameLodingPage';
+import GamePlayPage from './GamePlayPage';
+import ProfilePage from './ProfilePage';
+
+const PageSection = styled('section')(({ theme }) => ({
+  width: '100%',
+  height: '100%',
+  display: 'flex',
+  flexDirection: 'column',
+}));
+
+function PingpongLayout() {
+  return (
+    <PageSection>
+        <header>
+            <nav>
+            <NavigationBar></NavigationBar>
+            </nav>
+        </header>
+        <Routes>  
+            <Route path="profile" element={<ProfilePage />} />
+            <Route path="chatroom" element={<ChatroomPage />} />
+            <Route path="gamecreate" element={<GameCreatePage />} />
+            <Route path="gameplay" element={<GamePlayPage />} />
+            <Route path="gameloding" element={<GameLodingPage />} />
+        {/* 추후에 url을 통해 직접들어가지 못하고 game 버튼을 통해서만 접근 가능하도록 수정 */}
+        </Routes>
+    </PageSection>
+  );
+}
+
+export default PingpongLayout;

--- a/packages/client/src/pages/ProfilePage.tsx
+++ b/packages/client/src/pages/ProfilePage.tsx
@@ -18,9 +18,6 @@ const NavGridLayout = styled('div')(({ theme }) => ({
 function ProfilePage() {
   return (
     <ProfileLayout>
-      <NavGridLayout>
-        <NavigationBar></NavigationBar>
-      </NavGridLayout>
       <ProfileTemplate />
     </ProfileLayout>
   );


### PR DESCRIPTION
공통으로 작성되던 navbar를 sub route를 통해  공통 컴포넌트로 추출하였습니다.

"close #96"

### 💡 작업 동기 (Motivation)
- 컴포넌트 트리 작성 도중, navbar가 공통적으로 사용되는 문제 발견

### 💬 변경 사항 요약 (Key changes) 
- sub route를 통해 공통되는 레이아웃을 분할 시킴

### ✅  체크리스트
- [x] 각 기능에 대한 단위 테스트 및 통합 테스트를 수정|업데이트|추가했습니다(해당되는 경우).
- [x] 콘솔에 오류나 경고가 없습니다.
- [x] 개발된 기능의 스크린샷에 참여했습니다(해당되는 경우).

### 📸 스크린샷 첨부
<img width="269" alt="image" src="https://user-images.githubusercontent.com/55140432/192195349-386b6630-7320-464d-b11c-12692c458937.png">


### 📣 리뷰어들에게 요청사항
전체적인 레이아웃이 수정됨에 따라 특정 페이지의 컴포넌트의 위치값이 변하였습니다.
코드변경 참고하시고, 위치나 크기를 상대적인 값으로 수정해주세요