### PR TITLE
🐛 fix(server): addChannelParticipants 로직 수정 (#111)

### DIFF
--- a/packages/server/src/chats/dto/room.dto.ts
+++ b/packages/server/src/chats/dto/room.dto.ts
@@ -45,12 +45,14 @@ export class ChannelParticipantDto {
     auth: AUTH_TYPE,
     status: STATUS_TYPE,
     statusStartDate: Date,
+    blocked: boolean,
   ) {
     this.id = id;
     this.user = user;
     this.auth = auth;
     this.status = status;
     this.statusStartDate = statusStartDate;
+    this.blocked = blocked;
   }
 
   @ApiProperty()
@@ -67,4 +69,7 @@ export class ChannelParticipantDto {
 
   @ApiProperty()
   statusStartDate: Date;
+
+  @ApiProperty()
+  blocked: boolean;
 }

--- a/packages/server/src/chats/dto/rooms.dto.ts
+++ b/packages/server/src/chats/dto/rooms.dto.ts
@@ -86,14 +86,6 @@ export class PatchUserInfoDto {
   status: STATUS_TYPE;
 }
 
-// export class PatchUserStatusDto {
-//   @ApiProperty()
-//   @IsInt()
-//   @Min(0)
-//   @Max(1)
-//   status: STATUS_TYPE;
-// }
-
 /*************************/
 /*         DM dto        */
 /*************************/

--- a/packages/server/src/chats/dto/rooms.dto.ts
+++ b/packages/server/src/chats/dto/rooms.dto.ts
@@ -1,7 +1,8 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsInt, IsNotEmpty, IsString, IsUrl, Max, Min } from 'class-validator';
+import { RoomDto } from './room.dto';
 
-// union type들 모아두는 파일들 따로 만들기
+// FIXME[epic=sonkang] union type들 모아두는 파일들 따로 만들기
 const CHAT_TYPE = {
   dm: 0,
   public: 1,
@@ -22,10 +23,12 @@ const STATUS_TYPE = {
 } as const;
 export type STATUS_TYPE = typeof STATUS_TYPE[keyof typeof STATUS_TYPE];
 
-/*************************/
-/*      channel dto      */
-/*************************/
-export class CreateRoomDto {
+// ANCHOR Channel DTO
+export class CreateChannelDto {
+  @ApiProperty()
+  @IsInt()
+  userId: number;
+
   @ApiProperty()
   @IsString()
   name: string;
@@ -43,12 +46,32 @@ export class CreateRoomDto {
   @ApiProperty()
   @IsNotEmpty()
   title: string;
-}
 
-export class AddParticipantsDto {
   @ApiProperty()
   @IsInt()
   participantIds: number[];
+}
+
+export class GetUserChatsDto {
+  @ApiProperty()
+  dmsList: RoomDto[];
+
+  @ApiProperty()
+  channelsList: RoomDto[];
+}
+
+export class createDmDto {
+  @ApiProperty()
+  @IsInt()
+  userId: number;
+
+  @ApiProperty()
+  @IsInt()
+  participantId: number;
+
+  @ApiProperty()
+  @IsNotEmpty()
+  title: string;
 }
 
 export class RoomPasswordDto {
@@ -77,15 +100,11 @@ export class PatchUserInfoDto {
   @IsInt()
   @Min(0)
   @Max(1)
-  auth: AUTH_TYPE;
+  auth?: AUTH_TYPE;
 
   @ApiProperty()
   @IsInt()
   @Min(0)
   @Max(1)
-  status: STATUS_TYPE;
+  status?: STATUS_TYPE;
 }
-
-/*************************/
-/*         DM dto        */
-/*************************/

--- a/packages/server/src/chats/rooms.controller.ts
+++ b/packages/server/src/chats/rooms.controller.ts
@@ -16,11 +16,12 @@ import {
 } from '@nestjs/swagger';
 import { ChannelParticipantDto, RoomDto } from './dto/room.dto';
 import {
-  AddParticipantsDto,
-  CreateRoomDto,
+  CreateChannelDto,
   RoomPasswordDto,
   PatchRoomInfoDto,
   PatchUserInfoDto,
+  GetUserChatsDto,
+  createDmDto,
 } from './dto/rooms.dto';
 import { RoomService } from './rooms.service';
 import { UserDto } from '../users/dto/user.dto';
@@ -31,54 +32,74 @@ export class RoomsController {
   private logger = new Logger('RoomsController');
   constructor(private roomService: RoomService) {}
 
-  /********************************/
-  /*      channel controller      */
-  /********************************/
+  // ANCHOR Channel Controller
 
-  @Post()
-  @ApiOperation({ summary: '채팅방 생성' })
-  @ApiCreatedResponse({ description: '채팅방 생성 성공', type: RoomDto })
-  createRoom(@Body() createRoomDto: CreateRoomDto): Promise<RoomDto> {
-    this.logger.log(`createRoom: ${JSON.stringify(createRoomDto)}`);
-    return this.roomService.createRoom(createRoomDto);
+  @Post('/channels')
+  @ApiOperation({ summary: '채널 생성 BodyType: CreateChannelDto' })
+  @ApiCreatedResponse({
+    description: '채널 생성 성공 type: RoomDto',
+    type: RoomDto,
+  })
+  createChannel(@Body() createChannelDto: CreateChannelDto): Promise<RoomDto> {
+    this.logger.log(`createRoom: ${JSON.stringify(createChannelDto)}`);
+    return this.roomService.createChannel(createChannelDto);
   }
 
   @Get('/channels')
   @ApiOperation({ summary: '공개, 보호 채널 목록' })
   @ApiOkResponse({
-    description: '공개, 보호 채널 목록 가져오기 성공',
+    description: '공개, 보호 채널 목록 가져오기 성공 type: [RoomDto]',
     type: [RoomDto],
   })
+  // TODO: return값에 salt삭제 고민
   getChannels(): Promise<RoomDto[]> {
     this.logger.log(`getChannels`);
     return this.roomService.getChannels();
   }
 
+  // NOTE user controller로 옮기기
+  @Get('/:userId/chats')
+  @ApiOperation({ summary: 'user의 채널, DM 목록' })
+  @ApiOkResponse({
+    description: 'user의 채널, DM 목록 가져오기 성공 type: GetUserChatsDto',
+    type: GetUserChatsDto,
+  })
+  getUserChats(@Param('userId') userId: number): Promise<GetUserChatsDto> {
+    this.logger.log(`getUserChats`);
+    return this.roomService.getUserChats(userId);
+  }
+
   @Get('/channel/:roomId')
   @ApiOperation({ summary: '채팅방 정보 가져오기' })
-  @ApiOkResponse({ description: '채팅방 정보 가져오기 성공', type: RoomDto })
+  @ApiOkResponse({
+    description: '채팅방 정보 가져오기 성공 type: RoomDto',
+    type: RoomDto,
+  })
   getRoomInfo(@Param('roomId') roomId: number): Promise<RoomDto> {
     this.logger.log(`getRoomInfo`);
     return this.roomService.getRoomInfo(roomId);
   }
 
   @Post('/:roomId/users/:userId')
-  @ApiOperation({ summary: '채팅방 입장' })
-  @ApiOkResponse({ description: '채팅방 입장 성공', type: UserDto })
+  @ApiOperation({ summary: '채팅방 입장 BodyType: RoomPasswordDto' })
+  @ApiOkResponse({
+    description: '채팅방 입장 성공 type: UserDto',
+    type: UserDto,
+  })
   enterRoom(
     @Param('roomId') roomId: number,
     @Param('userId') userId: number,
     @Body() roomPasswordDto: RoomPasswordDto,
   ): Promise<UserDto> {
-    // 비밀번호가 없을 때는 빈 객체를 보내기
+    // NOTE 비밀번호가 없을 때는 빈 객체를 보내기
     return this.roomService.enterRoom(roomId, userId, roomPasswordDto);
   }
 
   @Get('/:roomId/channel/:userId/participants')
-  // userId를 body에 넣으려고 했으나 'addChannelParticipants' 주소와 같게 됨. 고민해보기
+  // FIXME[epic=sonkang] userId를 body에 넣으려고 했으나 'addChannelParticipants' 주소와 같게 됨. 고민해보기
   @ApiOperation({ summary: '채널 참여자 목록' })
   @ApiOkResponse({
-    description: '채널 참여자 목록 가져오기 성공',
+    description: '채널 참여자 목록 가져오기 성공 type: [ChannelParticipantDto]',
     type: [ChannelParticipantDto],
   })
   getChannelParticipants(
@@ -87,20 +108,6 @@ export class RoomsController {
   ): Promise<ChannelParticipantDto[]> {
     this.logger.log('getChannelParticipants');
     return this.roomService.getChannelParticipants(userId, roomId);
-  }
-
-  @Post('/:roomId/channel/participants')
-  @ApiOperation({ summary: '채널 참여자 추가' })
-  @ApiOkResponse({ description: '채널 참여자 추가 성공', type: [UserDto] })
-  addChannelParticipants(
-    @Param('roomId') roomId: number,
-    @Body() addChannelParticipantsDto: AddParticipantsDto,
-  ) {
-    this.logger.log('addChannelParticipant');
-    return this.roomService.addChannelParticipants(
-      roomId,
-      addChannelParticipantsDto,
-    );
   }
 
   @Delete('/:roomId/channel/participants/:userId')
@@ -121,7 +128,7 @@ export class RoomsController {
   }
 
   @Patch('/:roomId')
-  @ApiOperation({ summary: '체팅방 정보 수정' })
+  @ApiOperation({ summary: '체팅방 정보 수정 BodyType: PatchRoomInfoDto' })
   @ApiOkResponse({ description: '체팅방 정보 수정 성공' })
   patchRoomInfo(
     @Param('roomId') roomId: number,
@@ -132,7 +139,9 @@ export class RoomsController {
   }
 
   @Patch('/:roomId/users/:userId')
-  @ApiOperation({ summary: '채팅 유저 권한, 상태 변경' })
+  @ApiOperation({
+    summary: '채팅 유저 권한, 상태 변경 BodyType: PatchUserInfoDto',
+  })
   @ApiOkResponse({ description: '채팅 유저 권한, 상태 변경 성공' })
   patchUserInfo(
     @Param('roomId') roomId: number,
@@ -143,27 +152,21 @@ export class RoomsController {
     return this.roomService.patchUserInfo(roomId, userId, patchUserInfoDto);
   }
 
-  /********************************/
-  /*         DM controller        */
-  /********************************/
-
-  @Post(':roomId/dm/participants')
-  @ApiOperation({ summary: 'DM 참여자 추가' })
+  // ANCHOR DM Controller
+  @Post('/dm')
+  @ApiOperation({ summary: 'DM 채널 생성 BodyType: createDmDto' })
   @ApiCreatedResponse({
-    description: 'DM 참여자 추가 성공',
+    description: 'DM 채널 생성 type: [UserDto]',
     type: [UserDto],
   })
-  addDmParticipants(
-    @Param('roomId') roomId: number,
-    @Body() addParticipantsDto: AddParticipantsDto,
-  ) {
-    return this.roomService.addDmParticipants(roomId, addParticipantsDto);
+  createDm(@Body() createDmDto: createDmDto) {
+    return this.roomService.createDm(createDmDto);
   }
 
   @Get('/:roomId/dm/participants')
   @ApiOperation({ summary: 'DM 참여자 목록' })
   @ApiOkResponse({
-    description: 'DM 참여자 목록 가져오기 성공',
+    description: 'DM 참여자 목록 가져오기 성공 type: [UserDto]',
     type: [UserDto],
   })
   getDmParticipants(@Param('roomId') roomId: number) {

--- a/packages/server/src/chats/rooms.controller.ts
+++ b/packages/server/src/chats/rooms.controller.ts
@@ -74,17 +74,19 @@ export class RoomsController {
     return this.roomService.enterRoom(roomId, userId, roomPasswordDto);
   }
 
-  @Get('/:roomId/channel/participants')
+  @Get('/:roomId/channel/:userId/participants')
+  // userId를 body에 넣으려고 했으나 'addChannelParticipants' 주소와 같게 됨. 고민해보기
   @ApiOperation({ summary: '채널 참여자 목록' })
   @ApiOkResponse({
     description: '채널 참여자 목록 가져오기 성공',
     type: [ChannelParticipantDto],
   })
   getChannelParticipants(
+    @Param('userId') userId: number,
     @Param('roomId') roomId: number,
   ): Promise<ChannelParticipantDto[]> {
     this.logger.log('getChannelParticipants');
-    return this.roomService.getChannelParticipants(roomId);
+    return this.roomService.getChannelParticipants(userId, roomId);
   }
 
   @Post('/:roomId/channel/participants')

--- a/packages/server/src/chats/rooms.entity.ts
+++ b/packages/server/src/chats/rooms.entity.ts
@@ -13,7 +13,7 @@ export class Room {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @Column()
+  @Column({ nullable: true })
   name: string;
 
   @Column()

--- a/packages/server/src/database/database.providers.ts
+++ b/packages/server/src/database/database.providers.ts
@@ -14,7 +14,7 @@ export const databaseProviders = [
         entities: [__dirname + '/../**/*.entity{.ts,.js}'],
         synchronize: true,
         logging: true,
-        // console창에 query log를 볼 수 있는 option
+        // NOTE console창에 query log를 볼 수 있는 option
       });
       return dataSource.initialize();
     },


### PR DESCRIPTION
#111

### 💡 작업 동기 (Motivation)
getChannelParticipants함수에서 리턴값으로 각각의 participant에 대한 block 여부 추가

### 💬 변경 사항 요약 (Key changes) 
true, false로 block 여부를 알 수 있게 된다.

### ✅  체크리스트
- [ ] 각 기능에 대한 단위 테스트 및 통합 테스트를 수정|업데이트|추가했습니다(해당되는 경우).
- [x] 콘솔에 오류나 경고가 없습니다.
- [x] 개발된 기능의 스크린샷에 참여했습니다(해당되는 경우).

### 📸 스크린샷 첨부
<img width="1252" alt="스크린샷 2022-09-29 시간: 11 10 30" src="https://user-images.githubusercontent.com/60543629/192923541-d5c96958-41fc-4952-b237-34299b88d0e8.png">

### 📣 리뷰어들에게 요청사항

