### PR TITLE
🐛 fix(server): set maxId + 1 for every PK columns (#168)

### DIFF
--- a/packages/server/src/chats/rooms.entity.ts
+++ b/packages/server/src/chats/rooms.entity.ts
@@ -3,6 +3,7 @@ import {
   Entity,
   ManyToOne,
   OneToMany,
+  PrimaryColumn,
   PrimaryGeneratedColumn,
 } from 'typeorm';
 import { AUTH_TYPE, CHAT_TYPE, STATUS_TYPE } from './dto/rooms.dto';
@@ -10,7 +11,7 @@ import { User } from '../users/users.entity';
 
 @Entity()
 export class Room {
-  @PrimaryGeneratedColumn()
+  @PrimaryColumn()
   id: number;
 
   @Column({ nullable: true })
@@ -43,7 +44,7 @@ export class Room {
 
 @Entity()
 export class ChannelParticipant {
-  @PrimaryGeneratedColumn()
+  @PrimaryColumn()
   id: number;
 
   @Column({ nullable: true, type: 'integer' })
@@ -64,7 +65,7 @@ export class ChannelParticipant {
 
 @Entity()
 export class DmParticipant {
-  @PrimaryGeneratedColumn()
+  @PrimaryColumn()
   id: number;
 
   @ManyToOne(() => User, (user) => user.dmParticipants)
@@ -76,7 +77,7 @@ export class DmParticipant {
 
 @Entity()
 export class Message {
-  @PrimaryGeneratedColumn()
+  @PrimaryColumn()
   id: number;
 
   @Column()

--- a/packages/server/src/users/users.entity.ts
+++ b/packages/server/src/users/users.entity.ts
@@ -11,6 +11,7 @@ import {
   ManyToOne,
   OneToMany,
   OneToOne,
+  PrimaryColumn,
   PrimaryGeneratedColumn,
   Unique,
 } from 'typeorm';
@@ -24,7 +25,8 @@ export class User extends BaseEntity {
   }
 
   //TODO: 42API 제공 id를 사용하기 때문에, 추후 PrimaryColumn()으로 수정
-  @PrimaryGeneratedColumn()
+  // @PrimaryGeneratedColumn({ type: 'int' })
+  @PrimaryColumn()
   id: number;
 
   @Column({ unique: true })
@@ -55,7 +57,8 @@ export class User extends BaseEntity {
 @Entity()
 @Unique(['user', 'blockedUser'])
 export class Block extends BaseEntity {
-  @PrimaryGeneratedColumn()
+  // @PrimaryGeneratedColumn()
+  @PrimaryColumn()
   id: number;
 
   @Column()
@@ -70,7 +73,7 @@ export class Block extends BaseEntity {
 
 @Entity()
 export class Auth extends BaseEntity {
-  @PrimaryGeneratedColumn()
+  @PrimaryColumn()
   id: number;
 
   @Column()
@@ -87,7 +90,8 @@ export class Auth extends BaseEntity {
 @Entity()
 @Unique(['user', 'friend'])
 export class Friend extends BaseEntity {
-  @PrimaryGeneratedColumn()
+  // @PrimaryGeneratedColumn()
+  @PrimaryColumn()
   id: number;
 
   @ManyToOne(() => User, (user) => user.friends)
@@ -100,7 +104,8 @@ export class Friend extends BaseEntity {
 @Entity()
 @Unique(['requestor', 'responser'])
 export class Request extends BaseEntity {
-  @PrimaryGeneratedColumn()
+  // @PrimaryGeneratedColumn()
+  @PrimaryColumn()
   id: number;
 
   @ManyToOne(() => User, (user) => user.friends)

--- a/packages/server/src/users/users.service.ts
+++ b/packages/server/src/users/users.service.ts
@@ -33,13 +33,32 @@ export class UserService {
   async addUser(createUserDto: CreateUserDto): Promise<UserDto> {
     const { nickname, image, email } = createUserDto;
 
+    // FIXME: 테스트용
+    let id = 1;
+    const maxUserId = await this.usersRepository
+      .createQueryBuilder('user')
+      .select('MAX(user.id)', 'id')
+      .getRawOne();
+    if (maxUserId.id !== null) id = maxUserId.id + 1;
+
+    console.log(maxUserId.id);
     let user = this.usersRepository.create({
+      id,
       nickname,
       image,
     });
     user = await this.usersRepository.save(user);
 
+    // FIXME: 테스트용
+    let authId = 1;
+    const maxAuthId = await this.authRepository
+      .createQueryBuilder('auth')
+      .select('MAX(auth.id)', 'id')
+      .getRawOne();
+    if (maxAuthId.id !== null) authId = maxAuthId.id + 1;
+
     const auth = this.authRepository.create({
+      id: authId,
       email,
       authenticated: false,
       user,
@@ -122,7 +141,16 @@ export class UserService {
     });
     if (blockedUser === null) throw new EntityNotFoundError(User, id);
 
+    // FIXME: 테스트용
+    let blockId = 1;
+    const maxBlockId = await this.blocksRepository
+      .createQueryBuilder('block')
+      .select('MAX(block.id)', 'id')
+      .getRawOne();
+    if (maxBlockId != null) blockId = maxBlockId.id + 1;
+
     let block = this.blocksRepository.create({
+      id: blockId,
       blockedTime: new Date(),
       user: user,
       blockedUser: blockedUser,
@@ -226,11 +254,20 @@ export class UserService {
     });
     if (friend === null) throw new EntityNotFoundError(User, friendId);
 
+    let rowId = 1;
+    const maxFriendId = await this.friendsRepository
+      .createQueryBuilder('friend')
+      .select('MAX(friend.id)', 'id')
+      .getRawOne();
+    if (maxFriendId != null) rowId = maxFriendId.id + 1;
+
     const row1 = this.friendsRepository.create({
+      id: rowId + 1,
       user: user,
       friend: friend,
     });
     const row2 = this.friendsRepository.create({
+      id: rowId + 2,
       user: friend,
       friend: user,
     });
@@ -296,7 +333,15 @@ export class UserService {
     if (duplicateRequestCheck !== null || duplicateFriendCheck !== null)
       throw new ConflictException();
 
+    let rowId = 1;
+    const maxRequestId = await this.requestsRepository
+      .createQueryBuilder('request')
+      .select('MAX(request.id)', 'id')
+      .getRawOne();
+    if (maxRequestId != null) rowId = maxRequestId.id + 1;
+
     const row = this.requestsRepository.create({
+      id: rowId,
       requestor: user,
       responser: responser,
     });


### PR DESCRIPTION
#168

### 💡 작업 동기 (Motivation)
- DB 초기 값 설정 후, typeorm에서 save 시 PK duplicate key 에러 발생

### 💬 변경 사항 요약 (Key changes) 
- @PrimaryGeneratedColumn에서 @PrimaryColumn으로 변경
- 각 POST 요청에서 id가 필요한 경우, 현재 maxId를 찾은 후 + 1 값을 id로 설정

### ✅  체크리스트
- [ ] 각 기능에 대한 단위 테스트 및 통합 테스트를 수정|업데이트|추가했습니다(해당되는 경우).
- [x] 콘솔에 오류나 경고가 없습니다.
- [ ] 개발된 기능의 스크린샷에 참여했습니다(해당되는 경우).

### 📸 스크린샷 첨부

### 📣 리뷰어들에게 요청사항

---
- close #168 

