### PR TITLE
🐛 fix(server/chat): 불필요한 함수 삭제, return값 변경, controller 순서 변경 (#184)

### DIFF
--- a/packages/server/src/chats/dto/rooms.dto.ts
+++ b/packages/server/src/chats/dto/rooms.dto.ts
@@ -126,6 +126,12 @@ export class GetRoomInfoDto {
   @ApiProperty()
   @IsBoolean()
   blocked?: boolean;
+
+  @ApiProperty()
+  @IsInt()
+  @Min(0)
+  @Max(1)
+  auth?: AUTH_TYPE;
 }
 
 export class ChannelParticipantDto {

--- a/packages/server/src/chats/rooms.controller.ts
+++ b/packages/server/src/chats/rooms.controller.ts
@@ -57,6 +57,13 @@ export class RoomsController {
     return this.roomService.getChannels(userId);
   }
 
+  @Get('/messages/:roomId')
+  @ApiOperation({ summary: '채팅방 메시지 목록' })
+  getMessages(@Param('roomId') roomId: number) {
+    this.logger.log(`getMessages`);
+    return this.roomService.getMessages(roomId);
+  }
+
   @Get('/:roomId/:userId')
   @ApiOperation({ summary: '채팅방 정보 가져오기' })
   @ApiOkResponse({
@@ -84,12 +91,6 @@ export class RoomsController {
   ): Promise<ChannelParticipantDto[]> {
     this.logger.log('getChannelParticipants');
     return this.roomService.getChannelParticipants(userId, roomId);
-  }
-
-  @Get('/:roomId/messages')
-  @ApiOperation({ summary: '채팅방 메시지 목록' })
-  getMessages(@Param('roomId') roomId: number) {
-    return this.roomService.getMessages(roomId);
   }
 
   @Patch('/:roomId')

--- a/packages/server/src/chats/rooms.gateway.ts
+++ b/packages/server/src/chats/rooms.gateway.ts
@@ -36,20 +36,15 @@ export class RoomsGateway {
     return await this.roomService.enterChannel(client, enterChannelDto);
   }
 
-  @SubscribeMessage('leaveChannel')
-  async leaveChannel(
-    @ConnectedSocket() client: Socket,
-    @MessageBody() leaveChannelDto: LeaveChannelDto,
-  ) {
-    await this.roomService.leaveChannel(client, leaveChannelDto);
-  }
-
   @SubscribeMessage('deleteChannelParticipant')
   async deleteChannelParticipant(
     @ConnectedSocket() client: Socket,
     @MessageBody() leaveChannelDto: LeaveChannelDto,
   ) {
-    await this.roomService.deleteChannelParticipant(client, leaveChannelDto);
+    return await this.roomService.deleteChannelParticipant(
+      client,
+      leaveChannelDto,
+    );
   }
 
   @SubscribeMessage('sendMessage')

--- a/packages/server/src/main.ts
+++ b/packages/server/src/main.ts
@@ -28,7 +28,6 @@ async function bootstrap() {
       transform: true,
     }),
   );
-  // app.useWebSocketAdapter(new IoAdapter(app));
   const config = new DocumentBuilder()
     .setTitle('API design example')
     .setDescription('Example')


### PR DESCRIPTION
#184

### 💡 작업 동기 (Motivation)
deleteChannelParticipant : return값 필요
patchUserInfo : user의 nickname이 undefined여서 error 발생
leaveChannel : front에서 chat페이지를 나갔을 때 disconnect하므로
우려했던 부분인 실시간 채팅을 하지 않을 때도 소켓통신이 지속될 수 있다는 점이 해결되어 더이상 api가 필요없게 됨
getRoomInfo : front요청 user.auth 보내주기
controller에서 getMessages경로를 찾지 못하고 getRoomInfo 경로로 들어감
-> 이유 : controller 경로가 '/messages/:roomId', '/:roomId/:userId' 이었다. 이때 messages를 :roomId, 변수로 인식을 해버려 internal server error가 일어났다.
-> 해결 : 변수 endpoint를 아래로 내려서 변수로 받기 전 원하는 controller에 들어가도록 순서를 바꿈

### 💬 변경 사항 요약 (Key changes) 

### ✅  체크리스트
- [ ] 각 기능에 대한 단위 테스트 및 통합 테스트를 수정|업데이트|추가했습니다(해당되는 경우).
- [ ] 콘솔에 오류나 경고가 없습니다.
- [ ] 개발된 기능의 스크린샷에 참여했습니다(해당되는 경우).

### 📸 스크린샷 첨부

### 📣 리뷰어들에게 요청사항

