### PR TITLE
🐛 fix(server/game): 레더 매칭 로직 수정 (#179)

### DIFF
--- a/packages/server/src/game/game.dto.ts
+++ b/packages/server/src/game/game.dto.ts
@@ -45,18 +45,17 @@ export class GameRecordDto {
 }
 
 export class GameRoomDto {
-  id: string;
-
+  title: string;
   leftPlayer: UserDto;
   rightPlayer: UserDto;
-
+  ballPos: { x: number; y: number };
+  paddlePos: { left: number; right: number };
+  score: { left: number; right: number };
   mode: number;
 }
 
 export class MatchDto {
   userId: number;
-
-  mode: GAME_MODE;
 }
 
 export class RoomTitleDto {
@@ -64,10 +63,11 @@ export class RoomTitleDto {
 }
 
 export class GameInfoDto {
-  score: { left: number; right: number };
   ballPos: { x: number; y: number };
   paddlePos: { left: number; right: number };
-  mode: GAME_MODE;
+}
+export class GameScoreDto {
+  score: { left: number; right: number };
 }
 
 export class MovePaddleDto {
@@ -101,7 +101,7 @@ export class GameInfo {
 
   public getGameRoomDto(title: string): GameRoomDto {
     return {
-      id: title,
+      title: title,
       leftPlayer: {
         id: this.player.left.id,
         nickname: this.player.left.nickname,
@@ -112,16 +112,32 @@ export class GameInfo {
         nickname: this.player.right.nickname,
         image: this.player.right.image,
       },
+      ballPos: { x: this.ballPos.x, y: this.ballPos.y },
+      paddlePos: { left: this.paddlePos.left, right: this.paddlePos.right },
+      score: { left: this.score.left, right: this.score.right },
       mode: this.mode,
     };
   }
 
+  // public getGameInfoDto(): GameInfoDto {
+  //   return {
+  //     score: this.score,
+  //     ballPos: this.ballPos,
+  //     paddlePos: this.paddlePos,
+  //     mode: this.mode,
+  //   };
+  // }
+
   public getGameInfoDto(): GameInfoDto {
     return {
-      score: this.score,
       ballPos: this.ballPos,
       paddlePos: this.paddlePos,
-      mode: this.mode,
+    };
+  }
+
+  public getGameScoreDto(): GameScoreDto {
+    return {
+      score: this.score,
     };
   }
 }

--- a/packages/server/src/game/game.service.ts
+++ b/packages/server/src/game/game.service.ts
@@ -19,7 +19,7 @@ export class GameService {
     @Inject('USERS_REPOSITORY') private userRepository: Repository<User>,
     private schedulerRegistry: SchedulerRegistry,
   ) {}
-  private matchingQueue: MatchingInfo[][] = Array.from(Array(4), () => []);
+  private matchingQueue: MatchingInfo[] = [];
   private gameInfoMap: Map<string, GameInfo> = new Map();
 
   ballRadius = 10;
@@ -33,24 +33,21 @@ export class GameService {
     client.emit('gameMessage', data);
   }
 
+  // 매칭에는 게임설정이 없다
   async handleMatch(client: Socket, matchDto: MatchDto) {
     console.log('Game Client match', matchDto);
     // NOTE: 유저가 매칭을 요청하면, 매칭 대기열에 추가
 
     // NOTE: 매칭 대기열에 동일 유저가 있으면, WsException 발생
-    this.matchingQueue.map((eachQueue) => {
-      eachQueue.map((matchingInfo) => {
-        if (matchingInfo.userId === matchDto.userId)
-          throw new WsException('이미 매칭 대기열에 있습니다.');
-      });
+    this.matchingQueue.map((matchingInfo) => {
+      if (matchingInfo.userId === matchDto.userId)
+        throw new WsException('이미 매칭 대기열에 있습니다.');
     });
-    if (this.matchingQueue[matchDto.mode].length === 0) {
-      this.matchingQueue[matchDto.mode].push(
-        new MatchingInfo(matchDto.userId, client),
-      );
+    if (this.matchingQueue.length === 0) {
+      this.matchingQueue.push(new MatchingInfo(matchDto.userId, client));
     } else {
       // NOTE: 매칭 대기열에 유저가 있으면, 매칭(로직이 문제 없는 지 고민해봐야 함)
-      const opponent = this.matchingQueue[matchDto.mode].shift();
+      const opponent = this.matchingQueue.shift();
       const player1 = await this.userRepository.findOneBy({
         id: matchDto.userId,
       });
@@ -65,21 +62,20 @@ export class GameService {
       opponent.socket.join(title);
 
       this.gameInfoMap.set(title, gameInfo); // this.server
-      //   .to(gameInfo.title)
-      //   .emit('matched', gameInfo.getGameRoomDto());
       this.emitToEveryone(client, title, gameInfo.getGameRoomDto(title));
-      // emit event gameMessage로 통일
     }
   }
 
   async handleCancel(client: Socket, matchDto: MatchDto) {
     console.log('Game Client cancel', matchDto);
-    const index = this.matchingQueue[matchDto.mode].findIndex(
+    const index = this.matchingQueue.findIndex(
       (matchingInfo) => matchingInfo.socket.id === client.id,
     );
     // NOTE: 리스트에서 해당 유저를 삭제하기만 하면 되는데, 응답을 보내야할까?
-    this.matchingQueue[matchDto.mode].splice(index, 1);
+    this.matchingQueue.splice(index, 1);
     client.disconnect();
+    return { isCanceled: true };
+    // NOTE disconnect를 할지 방에서만 빼낼지 고민
   }
 
   async handleStart(client: Socket, roomTitleDto: RoomTitleDto) {
@@ -132,13 +128,12 @@ export class GameService {
           ) {
             message = '#############게임 끝################';
           }
-          this.emitToEveryone(client, title, {
-            leftScore: this.gameInfoMap.get(title).score.left,
-            rightScore: this.gameInfoMap.get(title).score.right,
-            message,
-          });
+          this.emitToEveryone(
+            client,
+            title,
+            this.gameInfoMap.get(title).getGameScoreDto(),
+          );
           this.schedulerRegistry.deleteInterval(title);
-          return;
         }
       }
       if (
@@ -152,13 +147,11 @@ export class GameService {
         this.gameInfoMap.get(title).ballSpeed.x;
       this.gameInfoMap.get(title).ballPos.y +=
         this.gameInfoMap.get(title).ballSpeed.y;
-      this.emitToEveryone(client, title, {
-        title: title,
-        x: x,
-        y: y,
-        leftPaddleY: leftPaddleY,
-        rightPaddleY: rightPaddleY,
-      });
+      this.emitToEveryone(
+        client,
+        title,
+        this.gameInfoMap.get(title).getGameInfoDto(),
+      );
     };
 
     const interval = setInterval(callback, milliseconds);

--- a/packages/server/src/game/game.service.ts
+++ b/packages/server/src/game/game.service.ts
@@ -134,6 +134,7 @@ export class GameService {
             this.gameInfoMap.get(title).getGameScoreDto(),
           );
           this.schedulerRegistry.deleteInterval(title);
+          return;
         }
       }
       if (


### PR DESCRIPTION
#179

### 💡 작업 동기 (Motivation)
- 프론트와 합의 후 matchQueue와 emit값의 변경 필요

### 💬 변경 사항 요약 (Key changes) 
- matchQueue에 이중배열이 필요 없어져 1차원 배열으로 수정
- emit해주는 값의 Dto 수정

### ✅  체크리스트
- [ ] 각 기능에 대한 단위 테스트 및 통합 테스트를 수정|업데이트|추가했습니다(해당되는 경우).
- [x] 콘솔에 오류나 경고가 없습니다.
- [ ] 개발된 기능의 스크린샷에 참여했습니다(해당되는 경우).

### 📸 스크린샷 첨부

### 📣 리뷰어들에게 요청사항

