### PR TITLE
✨ feat(server/chat): infinity scroll을 위해 getMessages 로직 수정 (#207)

### DIFF
--- a/packages/server/src/chats/dto/rooms.dto.ts
+++ b/packages/server/src/chats/dto/rooms.dto.ts
@@ -373,3 +373,17 @@ export class MessageDto {
   @IsNotEmpty()
   body: string;
 }
+
+export class GetMessageDto {
+  @IsObject()
+  @IsNotEmpty()
+  user: UserDto;
+
+  @IsNumber()
+  @IsNotEmpty()
+  id: number;
+
+  @IsString()
+  @IsNotEmpty()
+  body: string;
+}

--- a/packages/server/src/chats/rooms.controller.ts
+++ b/packages/server/src/chats/rooms.controller.ts
@@ -57,11 +57,14 @@ export class RoomsController {
     return this.roomService.getChannels(userId);
   }
 
-  @Get('/messages/:roomId')
+  @Get('/messages/:roomId/:messageId')
   @ApiOperation({ summary: '채팅방 메시지 목록' })
-  getMessages(@Param('roomId') roomId: number) {
+  getMessages(
+    @Param('roomId') roomId: number,
+    @Param('messageId') messageId: number,
+  ) {
     this.logger.log(`getMessages`);
-    return this.roomService.getMessages(roomId);
+    return this.roomService.getMessages(roomId, messageId);
   }
 
   @Get('/:roomId/:userId')

--- a/packages/server/src/chats/rooms.service.ts
+++ b/packages/server/src/chats/rooms.service.ts
@@ -20,6 +20,7 @@ import {
   MessageDto,
   GetRoomInfoDto,
   DmDto,
+  GetMessageDto,
 } from './dto/rooms.dto';
 import { Block, User } from '../users/users.entity';
 import { DmParticipant } from './rooms.entity';
@@ -307,20 +308,37 @@ export class RoomService {
   }
 
   // Message service
-  async getMessages(roomId: number): Promise<MessageDto[]> {
+  async getMessages(
+    roomId: number,
+    messageId: number,
+  ): Promise<GetMessageDto[]> {
     const msgs = await this.messagesRepository.find({
       relations: { user: true },
       where: { room: { id: roomId } },
-      order: { id: 'ASC' },
+      order: { id: 'DESC' },
     });
-    const result: MessageDto[] = [];
-    msgs.map((msg) => {
+    const result: GetMessageDto[] = [];
+    let idx = 0;
+    const msgResult = msgs.filter((msg) => {
+      if (
+        (!messageId && idx < 15) ||
+        (messageId && messageId > msg.id && idx < 15)
+      ) {
+        idx++;
+        return true;
+      } else return false;
+    });
+    msgResult.sort(function (a, b) {
+      return a.id - b.id;
+    });
+    msgResult.map((msg) => {
       const message = {
         user: {
           id: msg.user.id,
           nickname: msg.user.nickname,
           image: msg.user.image,
         },
+        id: msg.id,
         body: msg.body,
       };
       result.push(message);


### PR DESCRIPTION
#207

### 💡 작업 동기 (Motivation)
FE에서 처음부터 모든 메세지를 받지 않고, 일정한 수의 메세지를 보낸 다음, 유저가 스크롤 할 때 추가적인 메세지를 받길 원함
### 💬 변경 사항 요약 (Key changes) 

### ✅  체크리스트
- [ ] 각 기능에 대한 단위 테스트 및 통합 테스트를 수정|업데이트|추가했습니다(해당되는 경우).
- [x] 콘솔에 오류나 경고가 없습니다.
- [ ] 개발된 기능의 스크린샷에 참여했습니다(해당되는 경우).

### 📸 스크린샷 첨부

### 📣 리뷰어들에게 요청사항

