### PR TITLE
✨ feat(server/user): 2nd-auth login & 🔥 ladder match crash hotfix

### DIFF
--- a/packages/server/src/users/dto/auth-user.dto.ts
+++ b/packages/server/src/users/dto/auth-user.dto.ts
@@ -4,5 +4,5 @@ import { IsBoolean } from 'class-validator';
 export class AuthUserDto {
   @ApiProperty()
   @IsBoolean()
-  authenticated: boolean;
+  authenticated?: boolean;
 }

--- a/packages/server/src/users/dto/user.dto.ts
+++ b/packages/server/src/users/dto/user.dto.ts
@@ -162,7 +162,7 @@ export class PatchAuthDto {
   @ApiProperty({ example: 391082 })
   @IsInt()
   @IsOptional()
-  code: number;
+  code?: number;
 }
 
 export class IsBlockedDto {

--- a/packages/server/src/users/user.gateway.ts
+++ b/packages/server/src/users/user.gateway.ts
@@ -28,7 +28,10 @@ export class UserGateway implements OnGatewayConnection, OnGatewayDisconnect {
   server: Server;
 
   setConnection(userId: number, onGame: boolean) {
-    this.userService.setConnection(userId, this.server, onGame);
+    this.server.emit(
+      'changeUserStatus',
+      this.userService.setConnection(userId, onGame),
+    );
   }
 
   async handleConnection(client: Socket) {

--- a/packages/server/src/users/users.controller.ts
+++ b/packages/server/src/users/users.controller.ts
@@ -131,8 +131,8 @@ export class UsersController {
   @ApiOperation({
     summary: '2차 인증 업데이트 / BodyType: AuthUserDto',
     description:
-      '유저의 2차 인증 여부 반전(true -> false, false -> true)\
-      인증을 할 때는 이메일로 받은 code를 body에 포함하고, 해제 할 때는 바디에 아무것도 포함하지 않음',
+      '3가지 분기로 나뉨 (활성화 상태 / 바디 여부), 1. 2차 인증 활성화(false / O), \
+      2. 2차 인증 비활성화(true / X), 3. 2차 인증 로그인(true / O)',
   })
   @ApiOkResponse({ description: '2차 인증 업데이트 성공', type: AuthUserDto })
   @ApiBadRequestResponse({

--- a/packages/server/src/users/users.service.ts
+++ b/packages/server/src/users/users.service.ts
@@ -205,8 +205,10 @@ export class UserService {
     });
     const { code } = patchAuthDto;
 
+    console.log(this.authCodeList, code);
+
     if (code !== undefined || auth.authenticated === false) {
-      if (this.authCodeList.get(id) !== code)
+      if (this.authCodeList.get(id) !== code || code === undefined)
         throw new BadRequestException(
           '인증코드가 일치하지 않거나 만료되었습니다.',
         );

--- a/packages/server/src/users/users.service.ts
+++ b/packages/server/src/users/users.service.ts
@@ -32,7 +32,7 @@ import {
 import { v4 as uuidv4 } from 'uuid';
 import { Auth, Block, Friend, Request, User } from './users.entity';
 import { ConnectionDto, ConnectionsDto } from './dto/connect-user.dto';
-import { WebSocketGateway, WsException } from '@nestjs/websockets';
+import { WsException } from '@nestjs/websockets';
 import { MailerService } from '@nestjs-modules/mailer';
 import * as AWS from 'aws-sdk';
 
@@ -154,9 +154,10 @@ export class UserService {
       where: { user: { id: id } },
     });
 
-    const authCode = Math.floor(Math.random() * (1000000 - 100000)) + 100000;
+    // NOTE: 인증코드를 생성한다.(000000 ~ 999999)
+    const authCode = Math.floor(Math.random() * 1000000);
     this.authCodeList.set(id, authCode);
-    // NOTE: after 5 minutes, delete authCode
+    // NOTE: 생성한 코드는 5분 후에 만료된다.
     setTimeout(() => {
       this.authCodeList.delete(id);
     }, 5 * 60 * 1000);
@@ -202,23 +203,21 @@ export class UserService {
       relations: { user: true },
       where: { user: { id: id } },
     });
+    const { code } = patchAuthDto;
 
-    if (auth.authenticated === false) {
-      const { code } = patchAuthDto;
+    if (code !== undefined || auth.authenticated === false) {
       if (this.authCodeList.get(id) !== code)
         throw new BadRequestException(
           '인증코드가 일치하지 않거나 만료되었습니다.',
         );
       this.authCodeList.delete(id);
+      if (auth.authenticated === true) return { authenticated: true };
     }
 
     auth.authenticated = !auth.authenticated;
     await this.authRepository.save(auth);
 
-    const authUserDto = new AuthUserDto();
-    authUserDto.authenticated = auth.authenticated;
-
-    return authUserDto;
+    return { authenticated: auth.authenticated };
   }
 
   // ANCHOR: user block
@@ -546,7 +545,7 @@ export class UserService {
 
   // ANCHOR: Socket
 
-  setConnection(userId: number, server: Server | Socket, onGame: boolean) {
+  setConnection(userId: number, onGame: boolean) {
     let clientId: string;
     for (const [key, value] of this.connectionList) {
       if (value.userId === userId) {
@@ -560,15 +559,7 @@ export class UserService {
       connection.onGame,
     );
 
-    if (server instanceof Server) {
-      server.emit('changeUserStatus', {
-        connection: connectionDto,
-      });
-    } else {
-      server.broadcast.emit('changeUserStatus', {
-        connection: connectionDto,
-      });
-    }
+    return connectionDto;
   }
 
   getConnectionList() {
@@ -621,7 +612,10 @@ export class UserService {
     if (opponentClientId === null)
       throw new WsException('상대를 찾을 수 없습니다.');
 
-    this.setConnection(inviteGameDto.hostId, client, true);
+    client.broadcast.emit(
+      'changeUserStatus',
+      this.setConnection(inviteGameDto.hostId, true),
+    );
 
     const host = await this.usersRepository.findOne({
       where: [{ id: hostId }],
@@ -653,7 +647,11 @@ export class UserService {
     if (hostClientId === null)
       throw new WsException('호스트를 찾을 수 없습니다.');
 
-    this.setConnection(this.connectionList.get(client.id).userId, client, true);
+    client.broadcast.emit(
+      'changeUserStatus',
+      this.setConnection(this.connectionList.get(client.id).userId, true),
+    );
+
     const serverAcceptGameDto: ServerAcceptGameDto = {
       title: uuidv4(),
       mode: acceptGameDto.mode,


### PR DESCRIPTION
### 💡 작업 동기 (Motivation)
- 2차 인증 로그인 필요
- 래더 매치 시 크래시 발생

### 💬 변경 사항 요약 (Key changes) 
- patch /users/:id/2nd-auth API에 로그인 분기 추가(스웨거에서 명세 확인 가능)
- user gateway의 server을 service로 넘기던 로직을 넘기지 않고, 반환값만 받아서 처리

### ✅  체크리스트
- [ ] 각 기능에 대한 단위 테스트 및 통합 테스트를 수정|업데이트|추가했습니다(해당되는 경우).
- [x] 콘솔에 오류나 경고가 없습니다.
- [ ] 개발된 기능의 스크린샷에 참여했습니다(해당되는 경우).

### 📸 스크린샷 첨부

### 📣 리뷰어들에게 요청사항

---
- close #245 

