### PR TITLE
🐛 fix(server/auth): db에 없는 유저가 로그인했을 때 404 error 해결 (#284)

### DIFF
--- a/packages/server/src/auth/auth.service.ts
+++ b/packages/server/src/auth/auth.service.ts
@@ -1,13 +1,18 @@
-import { ForbiddenException, Injectable } from '@nestjs/common';
+import { ForbiddenException, Inject, Injectable } from '@nestjs/common';
 import { HttpService } from '@nestjs/axios';
 import { firstValueFrom } from 'rxjs';
 import { UserService } from '../users/users.service';
 import { v4 as uuidv4 } from 'uuid';
 import { JwtService } from '@nestjs/jwt';
+import { Repository } from 'typeorm';
+import { User } from '../users/users.entity';
+import { UserDto } from 'src/users/dto/user.dto';
 
 @Injectable()
 export class AuthService {
   constructor(
+    @Inject('USERS_REPOSITORY')
+    private usersRepository: Repository<User>,
     private readonly httpService: HttpService,
     private readonly userService: UserService,
     private readonly jwtService: JwtService,
@@ -29,7 +34,9 @@ export class AuthService {
     });
     if (response) {
       console.log(response.data.id);
-      let user = await this.userService.getUser(response.data.id);
+      let user: UserDto = await this.usersRepository.findOne({
+        where: { id: response.data.id },
+      });
       if (user) {
         return user;
       } else {


### PR DESCRIPTION
#284

### 💡 작업 동기 (Motivation)
- db에 없는 유저가 로그인했을 때 404 error가 남
<img width="1052" alt="image" src="https://user-images.githubusercontent.com/60543629/198481295-1814b2e3-35d3-4697-995a-e4f001007b7f.png">
<img width="1124" alt="image" src="https://user-images.githubusercontent.com/60543629/198481550-a4529799-9d2d-475e-b101-453bca4db597.png">

### 💬 변경 사항 요약 (Key changes) 
- user가 db에 있는지 확인할 때 userService의 getUser함수를 사용했는데 user가 없을 때 404 Not Found
   -> userRepository를 사용해 직접 찾고, 없다면 user를 생성함

### ✅  체크리스트
- [ ] 각 기능에 대한 단위 테스트 및 통합 테스트를 수정|업데이트|추가했습니다(해당되는 경우).
- [x] 콘솔에 오류나 경고가 없습니다.
- [ ] 개발된 기능의 스크린샷에 참여했습니다(해당되는 경우).

### 📸 스크린샷 첨부

### 📣 리뷰어들에게 요청사항

