### PR TITLE
✨ feat(server/game): get rank and game api & watch a game socket (#280)

### DIFF
--- a/packages/server/init/init.sql
+++ b/packages/server/init/init.sql
@@ -29,10 +29,10 @@ ALTER TABLE "rank" ADD CONSTRAINT "FK_0319fdc8ba0d4c2f456815dafea" FOREIGN KEY (
 
 INSERT INTO "user" ("id", "nickname", "image") VALUES (1, 'dha', 'https://cdn.intra.42.fr/users/dha.jpg');
 INSERT INTO "auth" ("id", "email", "authenticated", "userId") VALUES (1, 'dha@student.42seoul.kr', true, 1);
-INSERT INTO "rank" ("id", "rank", "win", "lose", "userId") VALUES (1, 0, 0, 0, 1);
+INSERT INTO "rank" ("id", "rank", "win", "lose", "userId") VALUES (1, 0, 2, 0, 1);
 INSERT INTO "user" ("id", "nickname", "image") VALUES (2, 'junghan', 'https://cdn.intra.42.fr/users/junghan.jpg');
 INSERT INTO "auth" ("id", "email", "authenticated", "userId") VALUES (2, 'junghan@student.42seoul.kr', false, 2);
-INSERT INTO "rank" ("id", "rank", "win", "lose", "userId") VALUES (2, 0, 0, 0, 2);
+INSERT INTO "rank" ("id", "rank", "win", "lose", "userId") VALUES (2, 0, 2, 0, 2);
 INSERT INTO "user" ("id", "nickname", "image") VALUES (3, 'doyun', 'https://cdn.intra.42.fr/users/doyun.jpg');
 INSERT INTO "auth" ("id", "email", "authenticated", "userId") VALUES (3, 'doyun@student.42seoul.kr', false, 3);
 INSERT INTO "rank" ("id", "rank", "win", "lose", "userId") VALUES (3, 0, 0, 0, 3);
@@ -77,4 +77,8 @@ INSERT INTO "channel_participant" ("id", "auth", "status", "statusStartDate", "u
 INSERT INTO "room" ("id", "name", "type", "salt", "title", "image") VALUES (3, NULL, 0, NULL, NULL, NULL);
 INSERT INTO "dm_participant" ("id", "userId", "roomId") VALUES (1, 1, 3);
 INSERT INTO "dm_participant" ("id", "userId", "roomId") VALUES (2, 2, 3);
+
+INSERT INTO "game" ("id", "win", "ladder", "userId", "opponentId") VALUES (1, true, true, 1, 2);
+INSERT INTO "game" ("id", "win", "ladder", "userId", "opponentId") VALUES (2, true, true, 1, 2);
+INSERT INTO "game" ("id", "win", "ladder", "userId", "opponentId") VALUES (3, false, false, 1, 2);
 COMMIT;

--- a/packages/server/src/game/game.dto.ts
+++ b/packages/server/src/game/game.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { UserDto } from 'src/users/dto/user.dto';
-import { User } from '../users/users.entity';
+import { Game, Rank, User } from '../users/users.entity';
 import { Socket } from 'socket.io';
 
 const GAME_MODE = {
@@ -18,6 +18,11 @@ const MOVE_DIR = {
 export type MOVE_DIR = typeof MOVE_DIR[keyof typeof MOVE_DIR];
 
 export class GameLadderDto {
+  constructor(rank: Rank) {
+    this.rank = rank.rank;
+    this.winCount = rank.win;
+    this.loseCount = rank.lose;
+  }
   @ApiProperty({ example: 1 })
   rank: number;
 
@@ -29,6 +34,13 @@ export class GameLadderDto {
 }
 
 export class GameRecordDto {
+  constructor(game: Game) {
+    const { id, win, ladder, opponent } = game;
+    this.id = id;
+    this.opponent = new UserDto(opponent.id, opponent.nickname, opponent.image);
+    this.isWin = win;
+    this.isLadder = ladder;
+  }
   @ApiProperty({ example: 1 })
   id: number;
 
@@ -60,6 +72,10 @@ export class MatchDto {
   userId: number;
 
   mode: GAME_MODE;
+}
+
+export class WatchDto {
+  userId: number;
 }
 
 export class MatchInfo {

--- a/packages/server/src/game/game.gateway.ts
+++ b/packages/server/src/game/game.gateway.ts
@@ -6,7 +6,13 @@ import {
   WebSocketServer,
 } from '@nestjs/websockets';
 import { Socket, Server } from 'socket.io';
-import { HandleStartDto, MatchDto, MovePaddleDto, SizeDto } from './game.dto';
+import {
+  HandleStartDto,
+  MatchDto,
+  MovePaddleDto,
+  SizeDto,
+  WatchDto,
+} from './game.dto';
 import { GameService } from './game.service';
 
 @WebSocketGateway(4242, {
@@ -50,5 +56,10 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
   @SubscribeMessage('resizeWindow')
   handleGameSize(client: Socket, sizeDto: SizeDto) {
     this.gameService.handleGameSize(client, sizeDto);
+  }
+
+  @SubscribeMessage('watch')
+  async handleWatch(client: Socket, watchDto: WatchDto) {
+    return await this.gameService.handleWatch(client, watchDto);
   }
 }

--- a/packages/server/src/game/game.service.ts
+++ b/packages/server/src/game/game.service.ts
@@ -10,6 +10,7 @@ import {
   SizeDto,
   HandleStartDto,
   GameScoreDto,
+  WatchDto,
 } from './game.dto';
 import { Game, Rank, User } from '../users/users.entity';
 import { Repository } from 'typeorm';
@@ -332,5 +333,17 @@ export class GameService {
 
   handleGameSize(client: Socket, sizeDto: SizeDto) {
     this.gameInfoMap.get(sizeDto.title).size = sizeDto.size;
+  }
+
+  async handleWatch(client: Socket, watchDto: WatchDto) {
+    const { userId } = watchDto;
+
+    for (const [key, value] of this.gameInfoMap) {
+      if (value.player.left.id === userId || value.player.right.id === userId) {
+        client.join(key);
+        return key;
+      }
+    }
+    throw new WsException('게임이 존재하지 않습니다');
   }
 }

--- a/packages/server/src/game/game.service.ts
+++ b/packages/server/src/game/game.service.ts
@@ -125,13 +125,23 @@ export class GameService {
 
   async addGameResult(addGameResultDto: AddGameResultDto) {
     const { players, score, mode } = addGameResultDto;
+
+    let id = 1;
+    const rank = await this.gamesRepository
+      .createQueryBuilder('game')
+      .select('MAX(rank.id)', 'id')
+      .getRawOne();
+    if (rank.id !== null) id = rank.id + 1;
+
     const result1 = this.gamesRepository.create({
+      id,
       win: score.left > score.right ? true : false,
       ladder: mode === 0 ? true : false,
       user: players.left,
       opponent: players.right,
     });
     const result2 = this.gamesRepository.create({
+      id: id + 1,
       win: score.left < score.right ? true : false,
       ladder: mode === 0 ? true : false,
       user: players.right,

--- a/packages/server/src/users/users.controller.ts
+++ b/packages/server/src/users/users.controller.ts
@@ -281,19 +281,7 @@ export class UsersController {
   })
   @ApiUnauthorizedResponse({ description: 'Unauthorized' })
   getLadderStat(@Param('id') id: number): Promise<GameLadderDto> {
-    return;
-  }
-
-  @Post('/:id/game/records')
-  @ApiTags('유저/게임')
-  @ApiOperation({ summary: '유저의 게임 기록 추가' })
-  @ApiCreatedResponse({
-    description: '유저 게임 기록 추가 성공',
-    type: GameRecordDto,
-  })
-  @ApiUnauthorizedResponse({ description: 'Unauthorized' })
-  addGameRecord(@Param('id') id: number): Promise<GameRecordDto> {
-    return;
+    return this.userService.getLadderStat(id);
   }
 
   @Get('/:id/game/records')
@@ -305,7 +293,7 @@ export class UsersController {
   })
   @ApiUnauthorizedResponse({ description: 'Unauthorized' })
   getGameRecords(@Param('id') id: number): Promise<GameRecordDto[]> {
-    return;
+    return this.userService.getGameRecords(id);
   }
 
   @Post('/:id/requests')


### PR DESCRIPTION
#280

### 💡 작업 동기 (Motivation)
- 게임 정보 API 미구현
- 관전 소켓 추가

### 💬 변경 사항 요약 (Key changes) 
- 유저의 랭크 정보 가져오기 추가 
- 유저의 게임 전적 가져오기 추가
- 관전 소켓 추가(watch) 
  ### handleWatch

  - 설명: 관전 요청
  - 이벤트명: `watch`
  - 입력 값: `WatchDto`
    
    ```tsx
    export class WatchDto {
      userId: number;
    }
    ```
    
  - 반환 값(Response)
    - 입장 성공: `{ title: string }`
    - 입장 실패(게임 중인 유저가 아닐 때): `exception` 
- 테스트용 game, rank 테이블 초기값 추가

### ✅  체크리스트
- [ ] 각 기능에 대한 단위 테스트 및 통합 테스트를 수정|업데이트|추가했습니다(해당되는 경우).
- [x] 콘솔에 오류나 경고가 없습니다.
- [ ] 개발된 기능의 스크린샷에 참여했습니다(해당되는 경우).

### 📸 스크린샷 첨부

### 📣 리뷰어들에게 요청사항

---
- close #280 
