### PR TITLE
✨ feat(server/auth): logout api & protect invalid access

### DIFF
--- a/packages/server/src/auth/auth.controller.ts
+++ b/packages/server/src/auth/auth.controller.ts
@@ -1,4 +1,12 @@
-import { Controller, Get, Request, Res, UseGuards } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Req,
+  Request,
+  Res,
+  UseGuards,
+} from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { AuthGuard } from '@nestjs/passport';
 import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
@@ -26,5 +34,13 @@ export class AuthController {
   async bakingKimAuthRedirect(@Request() req, @Res({ passthrough: true }) res) {
     // passthrough : 응답을 보내기 위한 옵션
     await this.authService.createJwtToken(req.user, res);
+  }
+
+  @Post('logout')
+  @ApiTags('로그아웃')
+  @ApiOperation({ summary: '로그아웃 요청' })
+  logout(@Req() req, @Res() res) {
+    res.setHeader('Set-Cookie', this.authService.logOut());
+    return res.sendStatus(200);
   }
 }

--- a/packages/server/src/auth/auth.module.ts
+++ b/packages/server/src/auth/auth.module.ts
@@ -32,7 +32,9 @@ import { ConfigModule } from '@nestjs/config';
     ...roomsProviders,
     bakingKimStrategy,
     JwtStrategy,
+    JwtModule,
   ],
   controllers: [AuthController],
+  exports: [JwtModule],
 })
 export class AuthModule {}

--- a/packages/server/src/auth/auth.service.ts
+++ b/packages/server/src/auth/auth.service.ts
@@ -63,4 +63,8 @@ export class AuthService {
     console.log('🥎🥎🥎🥎🥎🥎🥎🥎 우리가 만든 jwt token ', access_token);
     res.redirect(`http://localhost:3005/nickname`);
   }
+
+  logOut() {
+    return 'Authentication=; Path=/; HttpOnly; Max-Age=0';
+  }
 }

--- a/packages/server/src/chats/rooms.controller.ts
+++ b/packages/server/src/chats/rooms.controller.ts
@@ -9,6 +9,7 @@ import {
   UseGuards,
   UseInterceptors,
   UploadedFile,
+  Req,
 } from '@nestjs/common';
 import {
   ApiBody,
@@ -32,13 +33,17 @@ import {
 import { RoomService } from './rooms.service';
 import { AuthGuard } from '@nestjs/passport';
 import { FileInterceptor } from '@nestjs/platform-express';
+import { JwtService } from '@nestjs/jwt';
 
 @ApiTags('room')
 @Controller('rooms')
 @UseGuards(AuthGuard('jwt'))
 export class RoomsController {
   private logger = new Logger('RoomsController');
-  constructor(private roomService: RoomService) {}
+  constructor(
+    private roomService: RoomService,
+    private jwtService: JwtService,
+  ) {}
 
   // ANCHOR Channel Controller
 
@@ -72,9 +77,11 @@ export class RoomsController {
   getMessages(
     @Param('roomId') roomId: number,
     @Param('messageId') messageId: number,
+    @Req() req,
   ) {
     this.logger.log(`getMessages`);
-    return this.roomService.getMessages(roomId, messageId);
+    const { userId } = req.user;
+    return this.roomService.getMessages(roomId, messageId, userId);
   }
 
   @Get('/:roomId/:userId')

--- a/packages/server/src/chats/rooms.entity.ts
+++ b/packages/server/src/chats/rooms.entity.ts
@@ -1,11 +1,4 @@
-import {
-  Column,
-  Entity,
-  ManyToOne,
-  OneToMany,
-  PrimaryColumn,
-  PrimaryGeneratedColumn,
-} from 'typeorm';
+import { Column, Entity, ManyToOne, OneToMany, PrimaryColumn } from 'typeorm';
 import { AUTH_TYPE, CHAT_TYPE, STATUS_TYPE } from './dto/rooms.dto';
 import { User } from '../users/users.entity';
 

--- a/packages/server/src/chats/rooms.module.ts
+++ b/packages/server/src/chats/rooms.module.ts
@@ -5,8 +5,9 @@ import { RoomService } from './rooms.service';
 import { roomsProviders } from './rooms.providers';
 import { usersProviders } from '../users/users.providers';
 import { RoomsGateway } from './rooms.gateway';
+import { AuthModule } from 'src/auth/auth.module';
 @Module({
-  imports: [DatabaseModule],
+  imports: [DatabaseModule, AuthModule],
   controllers: [RoomsController],
   providers: [RoomService, RoomsGateway, ...roomsProviders, ...usersProviders],
 })

--- a/packages/server/src/chats/rooms.service.ts
+++ b/packages/server/src/chats/rooms.service.ts
@@ -4,6 +4,7 @@ import {
   NotFoundException,
   ConflictException,
   InternalServerErrorException,
+  UnauthorizedException,
 } from '@nestjs/common';
 import { Equal, Repository, In, Not } from 'typeorm';
 import { ChannelParticipant, Message, Room } from '../chats/rooms.entity';
@@ -30,6 +31,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { WsException } from '@nestjs/websockets';
 import * as AWS from 'aws-sdk';
 import * as bcrypt from 'bcryptjs';
+import { AuthorizationError } from 'passport-oauth2';
 
 @Injectable()
 export class RoomService {
@@ -106,6 +108,11 @@ export class RoomService {
   }
 
   async getChannels(userId: number): Promise<ChannelInfoDto[]> {
+    const user = await this.usersRepository.findOne({
+      where: { id: userId },
+    });
+    if (!user)
+      throw new NotFoundException(`유저(${userId})를 찾을 수 없습니다.`);
     const roomType = [1, 2];
     const channelLists = await this.roomsRepository.find({
       where: { type: In(roomType) },
@@ -152,6 +159,12 @@ export class RoomService {
     });
     // room이 dm일 때
     if (room.type == 0) {
+      const user = await this.dmParticipantsRepository.findOne({
+        relations: ['user'],
+        where: { room: { id: roomId }, user: { id: userId } },
+      });
+      if (!user)
+        throw new NotFoundException(`채널(${roomId}) 참여자가 아닙니다.`);
       const participant = await this.dmParticipantsRepository.findOne({
         relations: { user: true },
         where: { room: { id: roomId }, user: { id: Not(userId) } },
@@ -178,6 +191,8 @@ export class RoomService {
       const user = await this.channelParticipantsRepository.findOne({
         where: { room: { id: roomId }, user: { id: userId } },
       });
+      if (!user)
+        throw new NotFoundException(`채널(${roomId}) 참여자가 아닙니다.`);
       const roomInfo = {
         id: room.id,
         name: room.name,
@@ -195,6 +210,12 @@ export class RoomService {
     userId: number,
     roomId: number,
   ): Promise<ChannelParticipantDto[]> {
+    const user = await this.channelParticipantsRepository.findOne({
+      relations: ['user'],
+      where: { room: { id: roomId }, user: { id: userId } },
+    });
+    if (!user)
+      throw new NotFoundException(`채널(${roomId}) 참여자가 아닙니다.`);
     const blockUsers = await this.blocksRepository.find({
       relations: { blockedUser: true },
       where: { user: { id: userId } },
@@ -230,9 +251,9 @@ export class RoomService {
       );
       results.push(result);
     });
-    const user = results.filter((result) => result.user.id == userId);
+    const users = results.filter((result) => result.user.id == userId);
     const participants = results.filter((result) => result.user.id != userId);
-    return [user[0], ...participants];
+    return [users[0], ...participants];
   }
 
   async postChannelImage(roomId: number, file: Express.Multer.File) {
@@ -252,7 +273,7 @@ export class RoomService {
       await this.roomsRepository.save(room);
     } catch (error) {
       console.log(error);
-      throw new InternalServerErrorException();
+      throw new InternalServerErrorException('이미지 업로드를 실패했습니다.');
     }
 
     const channelDto = new ChannelDto(
@@ -351,7 +372,26 @@ export class RoomService {
   async getMessages(
     roomId: number,
     messageId: number,
+    userId: number,
   ): Promise<GetMessageDto[]> {
+    const room = await this.roomsRepository.findOneBy({ id: roomId });
+    if (!room) throw new NotFoundException(`Can't find room ${roomId}`);
+    if (room.type === 0) {
+      const dmParticipant = await this.dmParticipantsRepository.findOne({
+        relations: ['user', 'room'],
+        where: { room: { id: roomId }, user: { id: userId } },
+      });
+      if (!dmParticipant)
+        throw new UnauthorizedException('채팅방에 포함되지 않은 유저입니다.');
+    } else {
+      const channelParticipant =
+        await this.channelParticipantsRepository.findOne({
+          relations: ['user', 'room'],
+          where: { room: { id: roomId }, user: { id: userId } },
+        });
+      if (!channelParticipant)
+        throw new UnauthorizedException('채팅방에 포함되지 않은 유저입니다.');
+    }
     const msgs = await this.messagesRepository.find({
       relations: { user: true },
       where: { room: { id: roomId } },


### PR DESCRIPTION
### 💡 작업 동기 (Motivation)
- 로그아웃 API 필요
- 비정상접근 차단

### 💬 변경 사항 요약 (Key changes) 
- auth/logout API 
- rooms/users.service.ts 파일 중 userId로 가져오는 private 정보에서 roomId 및 userId 검증 로직 추가
- getMessages 함수에는 토큰 페이로드의 유저를 확인하여 해당 룸의 메세지를 읽을 수 있는 지 판단

### ✅  체크리스트
- [ ] 각 기능에 대한 단위 테스트 및 통합 테스트를 수정|업데이트|추가했습니다(해당되는 경우).
- [x] 콘솔에 오류나 경고가 없습니다.
- [ ] 개발된 기능의 스크린샷에 참여했습니다(해당되는 경우).

### 📸 스크린샷 첨부

### 📣 리뷰어들에게 요청사항

---
- close #291 
