### PR TITLE
🐛 fix(server/auth): unset AuthGuard in logout API (#302)

### DIFF
--- a/packages/server/src/auth/auth.controller.ts
+++ b/packages/server/src/auth/auth.controller.ts
@@ -1,6 +1,7 @@
 import {
   Controller,
   Get,
+  Header,
   Post,
   Req,
   Request,
@@ -13,10 +14,18 @@ import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { UserIdDto } from '../users/dto/user.dto';
 
 @Controller('auth')
-@UseGuards(AuthGuard('bakingKim'))
 export class AuthController {
   constructor(private authService: AuthService) {}
 
+  @Post('logout')
+  @ApiTags('로그아웃')
+  @Header('Set-Cookie', 'Authentication=; Path=/; HttpOnly; Max-Age=0')
+  @ApiOperation({ summary: '로그아웃 요청' })
+  logout() {
+    return { message: '로그아웃 되었습니다.' };
+  }
+
+  @UseGuards(AuthGuard('bakingKim'))
   @Get('login')
   @ApiTags('로그인')
   @ApiOperation({ summary: '로그인 요청' })
@@ -24,6 +33,7 @@ export class AuthController {
     return req.user;
   }
 
+  @UseGuards(AuthGuard('bakingKim'))
   @Get('bakingkim-redirect')
   @ApiTags('로그인')
   @ApiOperation({ summary: '로그인 후 토큰 제공' })
@@ -34,13 +44,5 @@ export class AuthController {
   async bakingKimAuthRedirect(@Request() req, @Res({ passthrough: true }) res) {
     // passthrough : 응답을 보내기 위한 옵션
     await this.authService.createJwtToken(req.user, res);
-  }
-
-  @Post('logout')
-  @ApiTags('로그아웃')
-  @ApiOperation({ summary: '로그아웃 요청' })
-  logout(@Req() req, @Res() res) {
-    res.setHeader('Set-Cookie', this.authService.logOut());
-    return res.sendStatus(200);
   }
 }


### PR DESCRIPTION
### 💡 작업 동기 (Motivation)
- 로그아웃 API 오류

### 💬 변경 사항 요약 (Key changes) 
- 로그아웃 API AuthGuard 미적용

### ✅  체크리스트
- [ ] 각 기능에 대한 단위 테스트 및 통합 테스트를 수정|업데이트|추가했습니다(해당되는 경우).
- [x] 콘솔에 오류나 경고가 없습니다.
- [ ] 개발된 기능의 스크린샷에 참여했습니다(해당되는 경우).

### 📸 스크린샷 첨부

### 📣 리뷰어들에게 요청사항

---
- close #302 
