### PR TITLE
🐛 fix(server/game): 매칭 중 game namespace에서 disconnect됐을 때 큐에서 삭제 (#312)

### DIFF
--- a/packages/server/src/game/game.gateway.ts
+++ b/packages/server/src/game/game.gateway.ts
@@ -39,11 +39,6 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
     return await this.gameService.handleMatch(client, matchDto);
   }
 
-  @SubscribeMessage('cancelMatch')
-  async handleCancel(client: Socket, matchDto: MatchDto) {
-    return await this.gameService.handleCancelMatch(client, matchDto);
-  }
-
   @SubscribeMessage('start')
   async handleStart(client: Socket, handleStartDto: HandleStartDto) {
     await this.gameService.handleStart(client, handleStartDto);

--- a/packages/server/src/game/game.service.ts
+++ b/packages/server/src/game/game.service.ts
@@ -28,10 +28,10 @@ export class GameService {
     private schedulerRegistry: SchedulerRegistry,
     private userGateway: UserGateway,
   ) {}
-  private matchingQueue: MatchInfo[] = [];
+  private matchingQueue: MatchInfo[] = []; // ladder
   private readyMap: Map<string, number> = new Map();
   private gameInfoMap: Map<string, GameInfo> = new Map();
-  private customMatchingMap: Map<string, MatchInfo> = new Map();
+  private customMatchingMap: Map<string, MatchInfo> = new Map(); // 1:1
 
   ballDiameter = 40;
   canvasWidth = 1024;
@@ -40,6 +40,7 @@ export class GameService {
   paddleHeight = 186;
 
   async handleDisconnect(client: Socket) {
+    // 게임 중 다른 페이지로 이동했을 때
     for (const [key, value] of this.gameInfoMap) {
       if (
         value.player.left.clientId === client.id ||
@@ -73,6 +74,14 @@ export class GameService {
         this.gameInfoMap.delete(key);
         this.schedulerRegistry.deleteInterval(key);
       }
+    }
+    // 게임 매치에서 다른 페이지로 이동했을 때
+    const index = this.matchingQueue.findIndex(
+      (matchingInfo) => matchingInfo.socket.id === client.id,
+    );
+
+    if (index !== -1) {
+      this.matchingQueue.splice(index, 1);
     }
   }
 
@@ -152,22 +161,6 @@ export class GameService {
       }
     }
     return { isMatched: true };
-  }
-
-  async handleCancelMatch(client: Socket, matchDto: MatchDto) {
-    console.log('Game Client cancel', matchDto);
-
-    if (!(await this.userGateway.setConnection(matchDto.userId, false))) {
-      throw new WsException('로그인 되지 않은 유저입니다.');
-    }
-
-    const index = this.matchingQueue.findIndex(
-      (matchingInfo) => matchingInfo.socket.id === client.id,
-    );
-    // NOTE: 리스트에서 해당 유저를 삭제하기만 하면 되는데, 응답을 보내야할까?
-    this.matchingQueue.splice(index, 1);
-    return { isCanceled: true };
-    // NOTE disconnect를 할지 방에서만 빼낼지 고민
   }
 
   async addGameResult(addGameResultDto: AddGameResultDto) {


### PR DESCRIPTION
#312

### 💡 작업 동기 (Motivation)
- 매칭 중 game namespace에서 disconnect할 때 matchingqueue에서 유저가 삭제되지 않음
### 💬 변경 사항 요약 (Key changes) 
- 매칭 중 game namespace에서 disconnect할 때 matchingqueue에서 유저를 삭제
### ✅  체크리스트
- [ ] 각 기능에 대한 단위 테스트 및 통합 테스트를 수정|업데이트|추가했습니다(해당되는 경우).
- [x] 콘솔에 오류나 경고가 없습니다.
- [ ] 개발된 기능의 스크린샷에 참여했습니다(해당되는 경우).

### 📸 스크린샷 첨부

### 📣 리뷰어들에게 요청사항

