### PR TITLE
🐛 fix(server/user): change GameRecordDto and its response order (#321)

### DIFF
--- a/packages/server/src/game/game.dto.ts
+++ b/packages/server/src/game/game.dto.ts
@@ -48,8 +48,9 @@ export class GameUserDto {
 
 export class GameRecordDto {
   constructor(game: Game) {
-    const { id, win, ladder, opponent } = game;
+    const { id, win, ladder, user, opponent } = game;
     this.id = id;
+    this.user = new UserDto(user.id, user.nickname, user.image);
     this.opponent = new UserDto(opponent.id, opponent.nickname, opponent.image);
     this.isWin = win;
     this.isLadder = ladder;
@@ -59,6 +60,15 @@ export class GameRecordDto {
 
   @ApiProperty({
     example: { id: 1, nickname: 'dha', image: 'https://cdn.42.fr/dha.jpg' },
+  })
+  user: UserDto;
+
+  @ApiProperty({
+    example: {
+      id: 2,
+      nickname: 'junghan',
+      image: 'https://cdn.42.fr/junghan.jpg',
+    },
   })
   opponent: UserDto;
 

--- a/packages/server/src/users/users.service.ts
+++ b/packages/server/src/users/users.service.ts
@@ -583,6 +583,7 @@ export class UserService {
     const gameRecords = await this.gamesRepository.find({
       relations: { user: true, opponent: true },
       where: { user: { id: id } },
+      order: { id: 'DESC' },
     });
 
     const gameRecordDtoList: GameRecordDto[] = [];


### PR DESCRIPTION
#321

### 💡 작업 동기 (Motivation)
- 프론트 전적 리스트 로직 변경
- 전적 리스트 정렬 방식 변경

### 💬 변경 사항 요약 (Key changes) 
- GameRecordDto에 User를 추가하여 응답
- DB에서 불러올 때, 순서 DESC 선택

### ✅  체크리스트
- [ ] 각 기능에 대한 단위 테스트 및 통합 테스트를 수정|업데이트|추가했습니다(해당되는 경우).
- [x] 콘솔에 오류나 경고가 없습니다.
- [ ] 개발된 기능의 스크린샷에 참여했습니다(해당되는 경우).

### 📸 스크린샷 첨부

### 📣 리뷰어들에게 요청사항

---
- close #321 