### PR TITLE
🐛 fix(server): init sql double quotes to single

### DIFF
--- a/packages/server/init/init.sql
+++ b/packages/server/init/init.sql
@@ -65,16 +65,16 @@ INSERT INTO "friend" ("id", "userId", "friendId") VALUES (12, 4, 2);
 INSERT INTO "request" ("id", "requestorId", "responserId") VALUES (1, 2, 5);
 INSERT INTO "request" ("id", "requestorId", "responserId") VALUES (2, 3, 5);
 
-INSERT INTO "room" ("id", "name", "type", "salt", "title", "image") VALUES (1, '42seoul', 1, NULL, "1283917239817", NULL);
+INSERT INTO "room" ("id", "name", "type", "salt", "title", "image") VALUES (1, '42seoul', 1, NULL, '128391723981a', NULL);
 INSERT INTO "channel_participant" ("id", "auth", "status", "statusStartDate", "userId", "roomId") VALUES (1, 0, NULL, NULL, 1, 1);
 INSERT INTO "channel_participant" ("id", "auth", "status", "statusStartDate", "userId", "roomId") VALUES (2, NULL, NULL, NULL, 2, 1);
 INSERT INTO "channel_participant" ("id", "auth", "status", "statusStartDate", "userId", "roomId") VALUES (3, NULL, NULL, NULL, 3, 1);
 INSERT INTO "channel_participant" ("id", "auth", "status", "statusStartDate", "userId", "roomId") VALUES (4, 1, 1, NULL, 4, 1);
 
-INSERT INTO "room" ("id", "name", "type", "salt", "title", "image") VALUES (2, '42tokyo', 1, NULL, "123123123", NULL);
+INSERT INTO "room" ("id", "name", "type", "salt", "title", "image") VALUES (2, '42tokyo', 1, NULL, '12312312a', NULL);
 INSERT INTO "channel_participant" ("id", "auth", "status", "statusStartDate", "userId", "roomId") VALUES (5, 0, NULL, NULL, 2, 2);
 
-INSERT INTO "room" ("id", "name", "type", "salt", "title", "image") VALUES (3, NULL, 0, NULL, "234234234", NULL);
+INSERT INTO "room" ("id", "name", "type", "salt", "title", "image") VALUES (3, NULL, 0, NULL, '23423423a', NULL);
 INSERT INTO "dm_participant" ("id", "userId", "roomId") VALUES (1, 1, 3);
 INSERT INTO "dm_participant" ("id", "userId", "roomId") VALUES (2, 2, 3);
 


### PR DESCRIPTION
### 💡 작업 동기 (Motivation)
- init.sql 수정 후 에러

### 💬 변경 사항 요약 (Key changes) 
- 쌍따옴표를 홑따옴표로 수정

### ✅  체크리스트
- [ ] 각 기능에 대한 단위 테스트 및 통합 테스트를 수정|업데이트|추가했습니다(해당되는 경우).
- [x] 콘솔에 오류나 경고가 없습니다.
- [ ] 개발된 기능의 스크린샷에 참여했습니다(해당되는 경우).

### 📸 스크린샷 첨부

### 📣 리뷰어들에게 요청사항

---
- close #329 