### PR TITLE
🐛 fix(server): filter blocked user messages in channel (#333)

### DIFF
--- a/packages/server/src/chats/rooms.service.ts
+++ b/packages/server/src/chats/rooms.service.ts
@@ -400,12 +400,20 @@ export class RoomService {
       where: { room: { id: roomId } },
       order: { id: 'DESC' },
     });
+    const blockIds = await this.blocksRepository.find({
+      relations: { blockedUser: true },
+      where: { user: { id: userId } },
+    });
     const result: GetMessageDto[] = [];
     let idx = 0;
     const msgResult = msgs.filter((msg) => {
+      const blocked = blockIds.find(
+        (block) => block.blockedUser.id === msg.user.id,
+      );
       if (
-        (!messageId && idx < count) ||
-        (messageId && messageId > msg.id && idx < count)
+        blocked === undefined &&
+        (!messageId || (messageId && messageId > msg.id)) &&
+        idx < count
       ) {
         idx++;
         return true;


### PR DESCRIPTION
#333

### 💡 작업 동기 (Motivation)
- getMessages에서 차단한 유저의 메세지를 제외하는 로직을 추가

### 💬 변경 사항 요약 (Key changes) 
- 차단한 유저의 메세지를 제외하면서 프론트에서 원하는 개수만큼 메세지를 전달

### ✅  체크리스트
- [ ] 각 기능에 대한 단위 테스트 및 통합 테스트를 수정|업데이트|추가했습니다(해당되는 경우).
- [x] 콘솔에 오류나 경고가 없습니다.
- [ ] 개발된 기능의 스크린샷에 참여했습니다(해당되는 경우).

### 📸 스크린샷 첨부

### 📣 리뷰어들에게 요청사항

