### PR TITLE
🐛 fix(server/rooms): 메세지가 없고 마지막 유저가 방을 나갔을 때 터지는 이슈 해결 (#357)

### DIFF
--- a/packages/server/src/chats/rooms.service.ts
+++ b/packages/server/src/chats/rooms.service.ts
@@ -516,7 +516,7 @@ export class RoomService {
           room: { id: roomId },
         });
         const ids = msgs.map((msg) => msg.id);
-        await this.messagesRepository.delete(ids);
+        if (ids.length !== 0) await this.messagesRepository.delete(ids);
         await this.roomsRepository.delete(roomId);
         return { isDeleted: true };
       }


### PR DESCRIPTION
#357

### 💡 작업 동기 (Motivation)
- 채팅방의 마지막 인원이 나가서 인원이 0명이 되는 경우 아래와 같은 에러를 띄우고 방이 사라지지지않음
- 방을 delete하기 전 messages를 지우는데 이때 메세지 id가 비어있다면 아래와 같은 에러를 띄움
<img width="2091" alt="image" src="https://user-images.githubusercontent.com/60543629/200787725-fcc2aa4d-71a6-4150-a484-54393333a652.png">

### 💬 변경 사항 요약 (Key changes) 
- 메세지가 DB에 있을 때만 삭제하도록 변경

### ✅  체크리스트
- [ ] 각 기능에 대한 단위 테스트 및 통합 테스트를 수정|업데이트|추가했습니다(해당되는 경우).
- [x] 콘솔에 오류나 경고가 없습니다.
- [ ] 개발된 기능의 스크린샷에 참여했습니다(해당되는 경우).

### 📸 스크린샷 첨부

### 📣 리뷰어들에게 요청사항

