### PR TITLE
🐛 fix(server/game): readyMap의 value를 초기화 (close #360)

### DIFF
--- a/packages/server/src/game/game.service.ts
+++ b/packages/server/src/game/game.service.ts
@@ -249,6 +249,7 @@ export class GameService {
         this.gameInfoMap.get(title).player.left.id,
         this.gameInfoMap.get(title).player.right.id,
       ].sort();
+      this.readyMap.delete(title);
       if (JSON.stringify(arr1) !== JSON.stringify(arr2))
         throw new WsException('There is an incorrect user in the game room.');
     }


### PR DESCRIPTION
close #360

### 💡 작업 동기 (Motivation)
![image](https://user-images.githubusercontent.com/60543629/200795852-31f370ac-ff0c-40b6-9b68-56962a1f00ac.png)
- 유저들이 게임 시작 api를 보내는 것을 확인하기 위한 readyMap에서 value를 초기화하지 않아
   제대로 된 확인이 불가

### 💬 변경 사항 요약 (Key changes) 
- room에 있는 유저들이 api를 보낸 것이 맞는지 확인한 후 readyMap value를 삭제하여
  다시 api를 보냈을 때 확인이 되게끔 변경
### ✅  체크리스트
- [ ] 각 기능에 대한 단위 테스트 및 통합 테스트를 수정|업데이트|추가했습니다(해당되는 경우).
- [x] 콘솔에 오류나 경고가 없습니다.
- [ ] 개발된 기능의 스크린샷에 참여했습니다(해당되는 경우).

### 📸 스크린샷 첨부

### 📣 리뷰어들에게 요청사항

